### PR TITLE
ci: build releases on macos-26 to match local SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   release:
     name: Build, Sign, Notarize & Release
-    runs-on: macos-14
+    runs-on: macos-26
 
     steps:
       - name: Checkout
@@ -33,10 +33,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: '5.9'
+      - name: Show toolchain
+        run: |
+          sw_vers
+          xcodebuild -version
+          xcrun --show-sdk-version
+          swift --version
 
       - name: Import codesigning certificates
         uses: apple-actions/import-codesign-certs@v2


### PR DESCRIPTION
## Summary
- Switch the release workflow runner from `macos-14` to `macos-26` so CI builds link against the same macOS 26 SDK used for local development.
- Drop the `swift-actions/setup-swift@v2` pin on Swift 5.9 and rely on the Xcode 26 toolchain preinstalled on the runner.
- Add a `Show toolchain` step that prints `sw_vers`, `xcodebuild`, SDK, and Swift versions to make future SDK drift easy to catch in build logs.

## Why
Locally-built DroidProxy renders Tahoe-style AppKit/SwiftUI controls (buttons, sliders, toggles) because the developer machine compiles against the macOS 26 SDK. The previous CI configuration ran on `macos-14` with Swift 5.9, producing binaries linked against the macOS 14 SDK and therefore rendering the older Sonoma control styles after release. Aligning the CI toolchain with the development environment removes the visual inconsistency between local builds and the distributed `.app`.

## Test plan
- [ ] Trigger the `Release` workflow manually (`workflow_dispatch`) and confirm the `Show toolchain` step reports macOS 26 and Xcode 26.
- [ ] Verify the resulting `DroidProxy-arm64.zip` installs, launches, and renders controls identically to a local `create-app-bundle.sh` build on macOS 26.
- [ ] Confirm codesigning, notarization, stapling, Sparkle signing, and appcast update steps still succeed end-to-end.