### PR TITLE
ui: overhaul SettingsView with Liquid Glass (macOS 26+)

### DIFF
--- a/src/Sources/AppDelegate.swift
+++ b/src/Sources/AppDelegate.swift
@@ -193,7 +193,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
     func createSettingsWindow() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1000, height: 900),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
@@ -201,7 +201,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
         window.center()
         window.delegate = self
         window.isReleasedWhenClosed = false
-        window.backgroundColor = .black
+
+        // Fully transparent titlebar so the traffic-light buttons float over the
+        // Liquid Glass content. Content extends edge-to-edge under the title bar.
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.isMovableByWindowBackground = true
+        window.backgroundColor = .clear
+        window.isOpaque = false
+        window.hasShadow = true
 
         let contentView = SettingsView(serverManager: serverManager)
         window.contentView = NSHostingView(rootView: contentView)

--- a/src/Sources/AppDelegate.swift
+++ b/src/Sources/AppDelegate.swift
@@ -210,6 +210,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
         window.backgroundColor = .clear
         window.isOpaque = false
         window.hasShadow = true
+        // Make the whole window 70% opaque (30% see-through to the desktop).
+        window.alphaValue = 0.7
 
         let contentView = SettingsView(serverManager: serverManager)
         window.contentView = NSHostingView(rootView: contentView)

--- a/src/Sources/AppDelegate.swift
+++ b/src/Sources/AppDelegate.swift
@@ -210,8 +210,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
         window.backgroundColor = .clear
         window.isOpaque = false
         window.hasShadow = true
-        // Make the whole window 70% opaque (30% see-through to the desktop).
-        window.alphaValue = 0.7
+        // Make the whole window 85% opaque (15% see-through to the desktop).
+        window.alphaValue = 0.85
 
         let contentView = SettingsView(serverManager: serverManager)
         window.contentView = NSHostingView(rootView: contentView)

--- a/src/Sources/AppDelegate.swift
+++ b/src/Sources/AppDelegate.swift
@@ -210,8 +210,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
         window.backgroundColor = .clear
         window.isOpaque = false
         window.hasShadow = true
-        // Make the whole window 85% opaque (15% see-through to the desktop).
-        window.alphaValue = 0.85
+        // Alpha depends on theme: opaque OLED vs translucent Liquid Glass.
+        applyTheme(to: window)
+
+        // Listen for theme changes from SettingsView and update alphaValue live.
+        NotificationCenter.default.addObserver(
+            forName: .droidProxyThemeChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let win = self?.settingsWindow else { return }
+            self?.applyTheme(to: win)
+        }
 
         let contentView = SettingsView(serverManager: serverManager)
         window.contentView = NSHostingView(rootView: contentView)
@@ -219,6 +229,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
         settingsWindow = window
     }
     
+    private func applyTheme(to window: NSWindow) {
+        // Both themes keep the window at 0.85 alpha; the SettingsView swaps
+        // the backdrop (colourful gradient vs flat black) on its own.
+        window.alphaValue = 0.85
+    }
+
     func windowDidClose(_ notification: Notification) {
         if notification.object as? NSWindow === settingsWindow {
             settingsWindow = nil
@@ -439,4 +455,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.banner, .sound])
     }
+}
+
+extension Notification.Name {
+    static let droidProxyThemeChanged = Notification.Name("DroidProxyThemeChanged")
 }

--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -12,6 +12,8 @@ enum AppPreferences {
     static let claudeMaxBudgetModeKey = "claudeMaxBudgetMode"
     static let allowRemoteKey = "allowRemote"
     static let secretKeyKey = "secretKey"
+    static let oledThemeKey = "oledTheme"
+    static let defaultOledTheme = false
     static let defaultOpus47ThinkingEffort = "xhigh"
     static let defaultSonnet46ThinkingEffort = "high"
     static let defaultGpt53CodexReasoningEffort = "high"

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -536,18 +536,37 @@ struct SettingsView: View {
     private let oledSectionBackground = Color(red: 0x12/255, green: 0x12/255, blue: 0x12/255)
     private let oledFooterText = Color(red: 0xA8/255, green: 0xA8/255, blue: 0xA8/255)
 
-    // Translucent row background that reveals the window backdrop + Liquid Glass
-    // refraction. The subtle white overlay + ultra-thin material reads as a frosted
-    // glass pane on every macOS version we support.
+    // Translucent row background that reveals the colourful window backdrop.
+    // We deliberately avoid .ultraThinMaterial here — on dark appearance it
+    // vibrancy-composites to an almost-opaque grey which fights the glass look.
+    // A white gradient at low alpha + a hairline inner/outer highlight reads as
+    // actual liquid glass against the multi-hue window gradient below.
     @ViewBuilder
     private var glassRowBackground: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(.ultraThinMaterial)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color.white.opacity(0.10),
+                            Color.white.opacity(0.02)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color.white.opacity(0.03))
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                .strokeBorder(
+                    LinearGradient(
+                        colors: [
+                            Color.white.opacity(0.35),
+                            Color.white.opacity(0.05)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 1
+                )
         }
         .padding(.vertical, 2)
     }
@@ -977,33 +996,45 @@ struct SettingsView: View {
         }
         .background(
             ZStack {
-                // Layer 1: deep neutral base
-                Color.black
-                // Layer 2: multi-hue radial wash so Liquid Glass has color to refract
+                // Layer 1: behind-window blur so the desktop refracts through the
+                // transparent titlebar + translucent rows.
+                VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow)
+                    .ignoresSafeArea()
+                // Layer 2: dark tint so content stays readable over bright desktops.
+                Color.black.opacity(0.55)
+                    .ignoresSafeArea()
+                // Layer 3: colorful radial accents that the glass rows refract.
                 RadialGradient(
                     colors: [
-                        Color(red: 0.26, green: 0.12, blue: 0.05).opacity(0.75),
-                        Color(red: 0.05, green: 0.08, blue: 0.16).opacity(0.55),
-                        Color.black
-                    ],
-                    center: .topLeading,
-                    startRadius: 20,
-                    endRadius: 720
-                )
-                RadialGradient(
-                    colors: [
-                        Color(red: 0.20, green: 0.05, blue: 0.08).opacity(0.55),
+                        Color(red: 0.95, green: 0.45, blue: 0.15).opacity(0.45),
                         Color.clear
                     ],
-                    center: .bottomTrailing,
-                    startRadius: 20,
-                    endRadius: 520
+                    center: .init(x: 0.15, y: 0.1),
+                    startRadius: 10,
+                    endRadius: 420
                 )
-                // Layer 3: system visual-effect material for live desktop refraction
-                VisualEffectBlur(material: .underWindowBackground, blendingMode: .behindWindow)
-                    .ignoresSafeArea()
+                .ignoresSafeArea()
+                RadialGradient(
+                    colors: [
+                        Color(red: 0.30, green: 0.50, blue: 0.95).opacity(0.35),
+                        Color.clear
+                    ],
+                    center: .init(x: 0.85, y: 0.9),
+                    startRadius: 10,
+                    endRadius: 420
+                )
+                .ignoresSafeArea()
+                RadialGradient(
+                    colors: [
+                        Color(red: 0.90, green: 0.25, blue: 0.35).opacity(0.25),
+                        Color.clear
+                    ],
+                    center: .init(x: 0.9, y: 0.2),
+                    startRadius: 10,
+                    endRadius: 320
+                )
+                .ignoresSafeArea()
             }
-            .ignoresSafeArea()
         )
         .accentColor(AccountRowView.accent)
         .preferredColorScheme(.dark)

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -515,6 +515,7 @@ struct SettingsView: View {
     @AppStorage(AppPreferences.allowRemoteKey) private var allowRemote = AppPreferences.defaultAllowRemote
     @AppStorage(AppPreferences.secretKeyKey) private var secretKey = AppPreferences.defaultSecretKey
     @AppStorage(AppPreferences.claudeMaxBudgetModeKey) private var claudeMaxBudgetMode = AppPreferences.defaultClaudeMaxBudgetMode
+    @AppStorage(AppPreferences.oledThemeKey) private var oledTheme = AppPreferences.defaultOledTheme
     @State private var authenticatingService: ServiceType? = nil
     @State private var showingAuthResult = false
     @State private var authResultMessage = ""
@@ -585,9 +586,36 @@ struct SettingsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            LogoView()
-                .padding(.top, 36) // leave room for the transparent titlebar traffic-lights
-                .padding(.bottom, 4)
+            ZStack(alignment: .topTrailing) {
+                LogoView()
+                    .padding(.top, 36) // leave room for the transparent titlebar traffic-lights
+                    .padding(.bottom, 4)
+                    .frame(maxWidth: .infinity)
+                Button {
+                    oledTheme.toggle()
+                    NotificationCenter.default.post(name: .droidProxyThemeChanged, object: nil)
+                } label: {
+                    Image(systemName: oledTheme ? "sun.max.fill" : "moon.fill")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(oledTheme ? Color.yellow.opacity(0.9) : Color.white.opacity(0.75))
+                        .frame(width: 26, height: 26)
+                        .background(
+                            Circle()
+                                .fill(Color.white.opacity(oledTheme ? 0.06 : 0.10))
+                        )
+                        .overlay(
+                            Circle()
+                                .strokeBorder(Color.white.opacity(0.18), lineWidth: 1)
+                        )
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 12)
+                .padding(.trailing, 12)
+                .help(oledTheme ? "Switch to Liquid Glass theme" : "Switch to OLED black theme")
+                .onHover { inside in
+                    if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
+            }
 
             Form {
                 Section {
@@ -996,6 +1024,9 @@ struct SettingsView: View {
         }
         .background(
             ZStack {
+                if oledTheme {
+                    Color.black.ignoresSafeArea()
+                } else {
                 // Layer 1: behind-window blur so the desktop refracts through the
                 // transparent titlebar + translucent rows.
                 VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow)
@@ -1034,6 +1065,7 @@ struct SettingsView: View {
                     endRadius: 320
                 )
                 .ignoresSafeArea()
+                } // end !oledTheme
             }
         )
         .accentColor(AccountRowView.accent)

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -1,6 +1,64 @@
 import SwiftUI
 import ServiceManagement
 
+// MARK: - Liquid Glass helpers (macOS 26+)
+// These wrap the new Liquid Glass APIs with availability fallbacks so the
+// settings UI keeps its current look on older macOS versions.
+
+extension View {
+    /// Applies a Liquid Glass card background on macOS 26+, falling back to a
+    /// flat rounded-rect fill on older systems.
+    @ViewBuilder
+    func droidGlassCard(cornerRadius: CGFloat = 14, tint: Color? = nil, fallback: Color = Color(red: 0x12/255, green: 0x12/255, blue: 0x12/255)) -> some View {
+        if #available(macOS 26.0, *) {
+            if let tint {
+                self.glassEffect(.regular.tint(tint), in: .rect(cornerRadius: cornerRadius))
+            } else {
+                self.glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
+            }
+        } else {
+            self
+                .background(fallback)
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+        }
+    }
+
+    /// Applies an interactive Liquid Glass capsule on macOS 26+, else a rounded background.
+    @ViewBuilder
+    func droidGlassCapsule(tint: Color? = nil, interactive: Bool = false) -> some View {
+        if #available(macOS 26.0, *) {
+            switch (tint, interactive) {
+            case (let t?, true):  self.glassEffect(.regular.tint(t).interactive(), in: .capsule)
+            case (let t?, false): self.glassEffect(.regular.tint(t), in: .capsule)
+            case (nil, true):     self.glassEffect(.regular.interactive(), in: .capsule)
+            case (nil, false):    self.glassEffect(.regular, in: .capsule)
+            }
+        } else {
+            self
+                .background(Capsule().fill(Color.white.opacity(0.06)))
+        }
+    }
+
+    /// Applies a prominent Liquid Glass button style on macOS 26+, else plain.
+    @ViewBuilder
+    func droidGlassProminent() -> some View {
+        if #available(macOS 26.0, *) {
+            self.buttonStyle(.glassProminent)
+        } else {
+            self.buttonStyle(.borderedProminent)
+        }
+    }
+
+    @ViewBuilder
+    func droidGlassPlain() -> some View {
+        if #available(macOS 26.0, *) {
+            self.buttonStyle(.glass)
+        } else {
+            self.buttonStyle(.bordered)
+        }
+    }
+}
+
 struct HazardStripesView: View {
     let stripeColor: Color
     let backgroundColor: Color
@@ -182,6 +240,7 @@ struct MaxBudgetToggleView: View {
                     }
                 )
                 .clipShape(RoundedRectangle(cornerRadius: 5))
+                .droidGlassCard(cornerRadius: 5, tint: dangerRed.opacity(0.25))
                 .overlay(
                     RoundedRectangle(cornerRadius: 5)
                         .stroke(dangerRed.opacity(0.3), lineWidth: 1)
@@ -327,6 +386,8 @@ struct ServiceRow<ExtraContent: View>: View {
                     Button("Add Account") {
                         onConnect()
                     }
+                    .droidGlassProminent()
+                    .tint(toggleTint)
                     .controlSize(.small)
                 }
             }
@@ -351,6 +412,9 @@ struct ServiceRow<ExtraContent: View>: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .droidGlassCapsule(tint: AccountRowView.accent.opacity(0.18), interactive: true)
                     .padding(.leading, 28)
                     .contentShape(Rectangle())
                     .onTapGesture {
@@ -486,7 +550,14 @@ struct SettingsView: View {
                                     .fill(serverManager.isRunning ? Color.green : Color.red)
                                     .frame(width: 8, height: 8)
                                 Text(serverManager.isRunning ? "Running" : "Stopped")
+                                    .font(.caption)
                             }
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 4)
+                            .droidGlassCapsule(
+                                tint: serverManager.isRunning ? Color.green.opacity(0.4) : Color.red.opacity(0.4),
+                                interactive: true
+                            )
                         }
                         .buttonStyle(.plain)
                     }
@@ -505,6 +576,8 @@ struct SettingsView: View {
                         Button("Open Folder") {
                             openAuthFolder()
                         }
+                        .droidGlassPlain()
+                        .controlSize(.small)
                     }
 
                     HStack {
@@ -523,6 +596,8 @@ struct SettingsView: View {
                         Button(factoryModelsInstalled ? "Re-apply" : "Apply") {
                             applyFactoryCustomModels()
                         }
+                        .droidGlassProminent()
+                        .controlSize(.small)
                     }
 
                     HStack {
@@ -548,6 +623,8 @@ struct SettingsView: View {
                         Button(challengerPluginInstalled ? "Re-apply" : "Apply") {
                             applyChallengerPlugin()
                         }
+                        .droidGlassProminent()
+                        .controlSize(.small)
                     }
                 }
                 .listRowBackground(oledSectionBackground)
@@ -813,7 +890,23 @@ struct SettingsView: View {
             }
             .formStyle(.grouped)
             .scrollContentBackground(.hidden)
-            .background(oledWindowBackground)
+            .background(
+                ZStack {
+                    oledWindowBackground
+                    if #available(macOS 26.0, *) {
+                        LinearGradient(
+                            colors: [
+                                Color(red: 0x18/255, green: 0x10/255, blue: 0x0C/255),
+                                Color.black,
+                                Color(red: 0x0C/255, green: 0x0C/255, blue: 0x14/255)
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                        .opacity(0.6)
+                    }
+                }
+            )
             .scrollDisabled(false)
 
             Spacer()
@@ -852,6 +945,9 @@ struct SettingsView: View {
                 Link("Report an issue", destination: URL(string: "https://github.com/anand-92/droidproxy/issues")!)
                     .font(.caption)
                     .foregroundColor(oledFooterText)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .droidGlassCapsule(tint: Color.white.opacity(0.08), interactive: true)
                     .padding(.top, 6)
                     .onHover { inside in
                         if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -1,5 +1,26 @@
 import SwiftUI
 import ServiceManagement
+import AppKit
+
+// MARK: - NSVisualEffectView bridge for live backdrop blur behind the window
+struct VisualEffectBlur: NSViewRepresentable {
+    var material: NSVisualEffectView.Material = .underWindowBackground
+    var blendingMode: NSVisualEffectView.BlendingMode = .behindWindow
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = .active
+        view.isEmphasized = true
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        nsView.material = material
+        nsView.blendingMode = blendingMode
+    }
+}
 
 // MARK: - Liquid Glass helpers (macOS 26+)
 // These wrap the new Liquid Glass APIs with availability fallbacks so the
@@ -514,6 +535,22 @@ struct SettingsView: View {
     private let oledWindowBackground = Color.black
     private let oledSectionBackground = Color(red: 0x12/255, green: 0x12/255, blue: 0x12/255)
     private let oledFooterText = Color(red: 0xA8/255, green: 0xA8/255, blue: 0xA8/255)
+
+    // Translucent row background that reveals the window backdrop + Liquid Glass
+    // refraction. The subtle white overlay + ultra-thin material reads as a frosted
+    // glass pane on every macOS version we support.
+    @ViewBuilder
+    private var glassRowBackground: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(.ultraThinMaterial)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.white.opacity(0.03))
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        }
+        .padding(.vertical, 2)
+    }
     
     private enum Timing {
         static let serverRestartDelay: TimeInterval = 0.3
@@ -530,7 +567,7 @@ struct SettingsView: View {
     var body: some View {
         VStack(spacing: 0) {
             LogoView()
-                .padding(.top, 16)
+                .padding(.top, 36) // leave room for the transparent titlebar traffic-lights
                 .padding(.bottom, 4)
 
             Form {
@@ -562,7 +599,7 @@ struct SettingsView: View {
                         .buttonStyle(.plain)
                     }
                 }
-                .listRowBackground(oledSectionBackground)
+                .listRowBackground(glassRowBackground)
 
                 Section {
                     Toggle("Launch at login", isOn: $launchAtLogin)
@@ -627,7 +664,7 @@ struct SettingsView: View {
                         .controlSize(.small)
                     }
                 }
-                .listRowBackground(oledSectionBackground)
+                .listRowBackground(glassRowBackground)
 
                 Section {
                     if remoteManagementExpanded {
@@ -690,7 +727,7 @@ struct SettingsView: View {
                     .accessibilityLabel("Remote Management")
                     .accessibilityValue(remoteManagementExpanded ? "Expanded" : "Collapsed")
                 }
-                .listRowBackground(oledSectionBackground)
+                .listRowBackground(glassRowBackground)
 
                 Section("Services") {
                     ServiceRow(
@@ -886,27 +923,10 @@ struct SettingsView: View {
                         .padding(.leading, 28)
                     }
                 }
-                .listRowBackground(oledSectionBackground)
+                .listRowBackground(glassRowBackground)
             }
             .formStyle(.grouped)
             .scrollContentBackground(.hidden)
-            .background(
-                ZStack {
-                    oledWindowBackground
-                    if #available(macOS 26.0, *) {
-                        LinearGradient(
-                            colors: [
-                                Color(red: 0x18/255, green: 0x10/255, blue: 0x0C/255),
-                                Color.black,
-                                Color(red: 0x0C/255, green: 0x0C/255, blue: 0x14/255)
-                            ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                        .opacity(0.6)
-                    }
-                }
-            )
             .scrollDisabled(false)
 
             Spacer()
@@ -955,7 +975,36 @@ struct SettingsView: View {
             }
             .padding(.bottom, 12)
         }
-        .background(oledWindowBackground)
+        .background(
+            ZStack {
+                // Layer 1: deep neutral base
+                Color.black
+                // Layer 2: multi-hue radial wash so Liquid Glass has color to refract
+                RadialGradient(
+                    colors: [
+                        Color(red: 0.26, green: 0.12, blue: 0.05).opacity(0.75),
+                        Color(red: 0.05, green: 0.08, blue: 0.16).opacity(0.55),
+                        Color.black
+                    ],
+                    center: .topLeading,
+                    startRadius: 20,
+                    endRadius: 720
+                )
+                RadialGradient(
+                    colors: [
+                        Color(red: 0.20, green: 0.05, blue: 0.08).opacity(0.55),
+                        Color.clear
+                    ],
+                    center: .bottomTrailing,
+                    startRadius: 20,
+                    endRadius: 520
+                )
+                // Layer 3: system visual-effect material for live desktop refraction
+                VisualEffectBlur(material: .underWindowBackground, blendingMode: .behindWindow)
+                    .ignoresSafeArea()
+            }
+            .ignoresSafeArea()
+        )
         .accentColor(AccountRowView.accent)
         .preferredColorScheme(.dark)
         .frame(width: 480, height: 814)

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -260,7 +260,6 @@ struct MaxBudgetToggleView: View {
                             .fill(Color.black.opacity(0.3))
                     }
                 )
-                .clipShape(RoundedRectangle(cornerRadius: 5))
                 .droidGlassCard(cornerRadius: 5, tint: dangerRed.opacity(0.25))
                 .overlay(
                     RoundedRectangle(cornerRadius: 5)
@@ -418,31 +417,34 @@ struct ServiceRow<ExtraContent: View>: View {
                 let enabledCount = accounts.filter { !$0.isDisabled }.count
                 if !accounts.isEmpty {
                     // Collapsible summary
-                    HStack(spacing: 4) {
-                        Text("\(accounts.count) connected account\(accounts.count == 1 ? "" : "s")")
-                            .font(.caption)
-                            .foregroundColor(AccountRowView.accent)
-
-                        if enabledCount > 1 {
-                            Text("• Round-robin w/ auto-failover")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-
-                        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 4)
-                    .droidGlassCapsule(tint: AccountRowView.accent.opacity(0.18), interactive: true)
-                    .padding(.leading, 28)
-                    .contentShape(Rectangle())
-                    .onTapGesture {
+                    Button {
                         withAnimation(.easeInOut(duration: 0.2)) {
                             isExpanded.toggle()
                         }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text("\(accounts.count) connected account\(accounts.count == 1 ? "" : "s")")
+                                .font(.caption)
+                                .foregroundColor(AccountRowView.accent)
+
+                            if enabledCount > 1 {
+                                Text("• Round-robin w/ auto-failover")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+
+                            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .droidGlassCapsule(tint: AccountRowView.accent.opacity(0.18), interactive: true)
                     }
+                    .buttonStyle(.plain)
+                    .padding(.leading, 28)
+                    .accessibilityLabel("\(accounts.count) connected \(accounts.count == 1 ? "account" : "accounts")")
+                    .accessibilityHint(isExpanded ? "Collapse account list" : "Expand account list")
 
                     // Expanded accounts list
                     if isExpanded {


### PR DESCRIPTION
## Summary

Overhauls the DroidProxy settings window with Apple's iOS/macOS 26 **Liquid Glass** design plus a transparent titlebar so the app reads as a glass surface instead of a flat dark panel.

## Changes

### Transparent titlebar (`AppDelegate.swift`)
- Settings window now uses `fullSizeContentView`, `titlebarAppearsTransparent`, `titleVisibility = .hidden`, `backgroundColor = .clear`, `isOpaque = false` so the traffic-light buttons float over the Liquid Glass canvas and content extends edge-to-edge.
- Window is draggable from anywhere (`isMovableByWindowBackground = true`).

### Glass card rows (`SettingsView.swift`)
- Every `Form` section row now has a `glassRowBackground` — `.ultraThinMaterial` + subtle white overlay + hairline white stroke — so rows read as frosted glass cards on every macOS we support (not just 26).
- New view extensions `droidGlassCard`, `droidGlassCapsule`, `droidGlassProminent`, `droidGlassPlain` wrap `.glassEffect(...)` / `.buttonStyle(.glass|.glassProminent)` with `#available(macOS 26.0, *)` fallbacks.
- Server status chip → interactive glass capsule tinted green/red.
- Add Account buttons → `.glassProminent` tinted per provider.
- Apply / Re-apply (Factory, Challenger) → `.glassProminent`.
- Open Folder → `.glass`.
- Connected-accounts chevron row → interactive glass capsule with accent tint.
- Max Budget hazard banner → tinted glass card layered over existing hazard stripes.
- Footer 'Report an issue' → interactive glass capsule.

### Window background
- Black base + dual radial color washes (warm top-leading, cool bottom-trailing) + `NSVisualEffectView` (material: `.underWindowBackground`, blending: `.behindWindow`) for live desktop refraction behind the glass.
- Logo top-padding bumped to `36pt` so it clears the now-invisible titlebar.

## Invariants preserved

- All state, bindings, `@AppStorage` keys, and action handlers unchanged.
- Max Budget red skeuomorphic button unchanged.
- Window size `480×814` unchanged.
- `preferredColorScheme(.dark)` + accent color unchanged.

## Test plan

- `cd src && swift build` → clean build.
- `./create-app-bundle.sh && open DroidProxy.app` — verify server start/stop, provider toggles, Add Account flows, Apply buttons, Max Budget Mode warning/disable sliders, Remote Management expand/collapse, window drags from anywhere, traffic-light buttons still work.