### PR TITLE
docs: drop task_budget mentions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,6 @@ What it does not do anymore:
 
 - It does not strip or normalize model suffixes
 - It does not send `thinking.budget_tokens` to Opus 4.7 (rejected with 400)
-- It does not inject `output_config.task_budget` or append the `task-budgets-2026-03-13` beta flag for any model
 - It does not add `anthropic-beta` interleaved-thinking headers (adaptive thinking enables interleaving automatically)
 - It does not implement the old `-thinking-N` / suffix-based branching documented in stale docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - **Claude Opus 4.7 migration** -- Opus 4.6 support replaced with Opus 4.7 throughout the app: model detection (`claude-opus-4-7`), Settings UI label, Factory custom models entry (`custom:droidproxy:opus-4-7`), and the bundled Challenger droid (`challenger-opus`) now target Opus 4.7. Effort options are `low` / `medium` / `high` / `xhigh` / `max`, with a default of `xhigh` per Anthropic's recommendation for coding and agentic workloads.
-- **Max Budget Mode scoped to Sonnet 4.6** -- The big red button now only overrides Sonnet 4.6, injecting `thinking: {type: enabled, budget_tokens: 63999}` with `max_tokens: 64000` and `effort: max`. Opus 4.7 is excluded: its requests follow the configured Opus 4.7 effort slider regardless of the toggle. The `task_budget` injection and `task-budgets-2026-03-13` beta header are removed, and the Settings UI reflects the Sonnet-only scope with a `MAX MODE` badge on the Sonnet effort picker and an untouched Opus 4.7 picker.
 - **Opus 4.6 Factory custom model** -- `custom:droidproxy:opus-4-6` is removed from `customModels` during Apply/Re-apply so users don't end up with stale entries alongside the new Opus 4.7 model.
 
 ### Added


### PR DESCRIPTION
## Summary
- Removes the `Max Budget Mode scoped to Sonnet 4.6` bullet from the Unreleased section of `CHANGELOG.md`.
- Removes the `It does not inject output_config.task_budget...` bullet from the "What it does not do anymore" list in `AGENTS.md`.

## Why
The `task_budget` / `task-budgets-2026-03-13` path never shipped to users, so documenting its removal adds noise without signal. Keeping the docs focused on current shipping behavior.

## Test plan
- [ ] Skim the rendered CHANGELOG and AGENTS on GitHub and confirm no orphaned references to `task_budget` remain.