### PR TITLE
fix(thinking-proxy): crash on non-ASCII /v1/messages bodies (#42)

### DIFF
--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -393,13 +393,13 @@ class ThinkingProxy {
         let valuePattern = "(?:\"(?:[^\"\\\\]|\\\\.)*\"|\\-?\\d+(?:\\.\\d+)?|\\{[^}]*\\}|\\[[^\\]]*\\]|true|false|null)"
         let pattern = "(\"\(escapedKey)\"\\s*:\\s*)\(valuePattern)"
         guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: json, range: NSRange(json.startIndex..., in: json)) else {
+              let match = regex.firstMatch(in: json, range: NSRange(json.startIndex..., in: json)),
+              let matchRange = Range(match.range, in: json),
+              let prefixRange = Range(match.range(at: 1), in: json) else {
             NSLog("[ThinkingProxy] Warning: Could not find key '\(fieldName)' for value replacement")
             return json
         }
         var result = json
-        let matchRange = Range(match.range, in: json)!
-        let prefixRange = Range(match.range(at: 1), in: json)!
         let prefix = String(json[prefixRange])
         result.replaceSubrange(matchRange, with: "\(prefix)\(newValue)")
         return result
@@ -453,12 +453,12 @@ class ThinkingProxy {
         let escaped = NSRegularExpression.escapedPattern(for: oldModel)
         let pattern = "(\"model\"\\s*:\\s*\")\(escaped)(\")"
         guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: json, range: NSRange(json.startIndex..., in: json)) else {
+              let match = regex.firstMatch(in: json, range: NSRange(json.startIndex..., in: json)),
+              let matchRange = Range(match.range, in: json) else {
             NSLog("[ThinkingProxy] Warning: Could not find model value '\(oldModel)' for rewrite")
             return json
         }
         var result = json
-        let matchRange = Range(match.range, in: json)!
         let replacement = "\"model\":\"\(newModel)\""
         result.replaceSubrange(matchRange, with: replacement)
         return result
@@ -470,19 +470,21 @@ class ThinkingProxy {
     // alphabetically, which breaks Anthropic's prompt cache matching.
 
     /// Injects a new JSON field after a given key's value in the JSON string.
+    /// Uses `Range(_:in:)` to convert the NSRegularExpression UTF-16 range into a
+    /// `String.Index`. Mixing UTF-16 offsets with `String.index(_:offsetBy:)`
+    /// (which walks Characters) traps on any body containing non-ASCII graphemes.
     private func injectJSONField(in json: String, afterKey: String, fieldName: String, fieldValue: String) -> String {
         let escapedKey = NSRegularExpression.escapedPattern(for: afterKey)
         let valuePattern = "(?:\"(?:[^\"\\\\]|\\\\.)*\"|\\-?\\d+(?:\\.\\d+)?|\\{[^}]*\\}|\\[[^\\]]*\\]|true|false|null)"
         let pattern = "\"\(escapedKey)\"\\s*:\\s*\(valuePattern)"
         guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: json, range: NSRange(json.startIndex..., in: json)) else {
+              let match = regex.firstMatch(in: json, range: NSRange(json.startIndex..., in: json)),
+              let matchRange = Range(match.range, in: json) else {
             NSLog("[ThinkingProxy] Warning: Could not find key '\(afterKey)' for field injection")
             return json
         }
-        let insertOffset = match.range.location + match.range.length
-        let insertIndex = json.index(json.startIndex, offsetBy: insertOffset)
         var result = json
-        result.insert(contentsOf: ",\"\(fieldName)\":\(fieldValue)", at: insertIndex)
+        result.insert(contentsOf: ",\"\(fieldName)\":\(fieldValue)", at: matchRange.upperBound)
         return result
     }
 


### PR DESCRIPTION
## Summary

Fixes #42. `ThinkingProxy` crashed with `EXC_BREAKPOINT / SIGTRAP` inside `injectJSONField(...)` on Anthropic `/v1/messages` traffic. The bundled `CLIProxyMenuBar` was restarted by macOS after each crash.

## Root cause

`injectJSONField` mixed two incompatible offset domains:

- `NSRegularExpression.firstMatch` returns `NSRange` in **UTF-16 code units**.
- `String.index(_:offsetBy:)` walks **Characters** (grapheme clusters).

For pure-ASCII bodies the two offsets coincide and the helper happens to land on the correct `String.Index`. As soon as the request body contains a grapheme that needs more than one UTF-16 unit (emoji, many CJK sequences, combining marks, ZWJ sequences, ...), `offsetBy` either walks past `endIndex` — hitting `_assertionFailure` → `SIGTRAP` (the reported crash) — or lands at the wrong scalar boundary and corrupts the JSON, which explains the paired upstream `400 invalid_request_error: The request body is not valid JSON: unexpected content after document` reports.

The helper was introduced in commit `e92f578` ("refactor: clean up ThinkingProxy surgical JSON helpers"), which replaced a `String.Index`-only insertion with this regex-based one.

## Fix

Convert the `NSRange` back to a `Range<String.Index>` via `Range(_:in:)` — the same pattern `replaceJSONFieldValue` and `rewriteModelValue` already use. ASCII output is byte-for-byte identical to the previous implementation.

Also soften the `Range(...)!` force-unwraps in `replaceJSONFieldValue` and `rewriteModelValue` to `guard let`s so the same bug class can't be reintroduced silently later.

## Validation

- `cd src && swift build` clean.
- Extracted `injectJSONField` into a standalone Swift script and ran against ASCII / emoji / CJK / combining-mark / ZWJ-sequence payloads:
  - **New:** every case produces valid JSON with `"thinking":{"type":"adaptive"}` inserted immediately after `"model":"..."`.
  - **Old:** the emoji case yielded `"claude-opus-4-7",,"thinking":{...}"max_tokens"` (the paired 400 reproducer); the combining-mark case spliced `,"thinking":{...}` into the middle of the `max_tokens` key name.
- Reviewed with a devil's-advocate pass on the whole helper surface; the UTF-16/Character mismatch is the only stack-matching theory.

## Out of scope / follow-ups

- The regex value-pattern (`\{[^}]*\}` etc.) is not a real JSON parser and can false-match on nested/escaped payloads. Replacing surgical regex with a small top-level JSON scanner is the right long-term fix; filing separately.
- `receiveNextChunk` forwards the entire accumulated TCP buffer to `processRequest` rather than slicing to declared `Content-Length`. Could produce `unexpected content after document` independently of the crash; filing separately.

## Repro confirmation

Also reviewed the live `/tmp/droidproxy-debug.log` on the reporter-adjacent build: 297 consecutive Opus 4.7 `/v1/messages` calls — every one pure-ASCII `system-reminder` prompts — succeeded. Matches the "works fine until the body has non-ASCII content" profile.

Fixes #42