### PR TITLE
feat: add Opus 4.6 and 4.5 support alongside Opus 4.7

### DIFF
--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -39,19 +39,11 @@ enum AppPreferences {
     }
 
     static var opus46ThinkingEffort: String {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: opus46ThinkingEffortKey) != nil else {
-            return defaultOpus46ThinkingEffort
-        }
-        return defaults.string(forKey: opus46ThinkingEffortKey) ?? defaultOpus46ThinkingEffort
+        UserDefaults.standard.string(forKey: opus46ThinkingEffortKey) ?? defaultOpus46ThinkingEffort
     }
 
     static var opus45ThinkingEffort: String {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: opus45ThinkingEffortKey) != nil else {
-            return defaultOpus45ThinkingEffort
-        }
-        return defaults.string(forKey: opus45ThinkingEffortKey) ?? defaultOpus45ThinkingEffort
+        UserDefaults.standard.string(forKey: opus45ThinkingEffortKey) ?? defaultOpus45ThinkingEffort
     }
 
     static var sonnet46ThinkingEffort: String {

--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -2,6 +2,8 @@ import Foundation
 
 enum AppPreferences {
     static let opus47ThinkingEffortKey = "opus47ThinkingEffort"
+    static let opus46ThinkingEffortKey = "opus46ThinkingEffort"
+    static let opus45ThinkingEffortKey = "opus45ThinkingEffort"
     static let sonnet46ThinkingEffortKey = "sonnet46ThinkingEffort"
     static let gpt53CodexReasoningEffortKey = "gpt53CodexReasoningEffort"
     static let gpt54ReasoningEffortKey = "gpt54ReasoningEffort"
@@ -15,6 +17,8 @@ enum AppPreferences {
     static let oledThemeKey = "oledTheme"
     static let defaultOledTheme = false
     static let defaultOpus47ThinkingEffort = "xhigh"
+    static let defaultOpus46ThinkingEffort = "max"
+    static let defaultOpus45ThinkingEffort = "high"
     static let defaultSonnet46ThinkingEffort = "high"
     static let defaultGpt53CodexReasoningEffort = "high"
     static let defaultGpt54ReasoningEffort = "high"
@@ -32,6 +36,22 @@ enum AppPreferences {
             return defaultOpus47ThinkingEffort
         }
         return defaults.string(forKey: opus47ThinkingEffortKey) ?? defaultOpus47ThinkingEffort
+    }
+
+    static var opus46ThinkingEffort: String {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: opus46ThinkingEffortKey) != nil else {
+            return defaultOpus46ThinkingEffort
+        }
+        return defaults.string(forKey: opus46ThinkingEffortKey) ?? defaultOpus46ThinkingEffort
+    }
+
+    static var opus45ThinkingEffort: String {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: opus45ThinkingEffortKey) != nil else {
+            return defaultOpus45ThinkingEffort
+        }
+        return defaults.string(forKey: opus45ThinkingEffortKey) ?? defaultOpus45ThinkingEffort
     }
 
     static var sonnet46ThinkingEffort: String {

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -507,6 +507,8 @@ struct SettingsView: View {
     @StateObject private var authManager = AuthManager()
     @State private var launchAtLogin = false
     @AppStorage(AppPreferences.opus47ThinkingEffortKey) private var opus47ThinkingEffort = AppPreferences.defaultOpus47ThinkingEffort
+    @AppStorage(AppPreferences.opus46ThinkingEffortKey) private var opus46ThinkingEffort = AppPreferences.defaultOpus46ThinkingEffort
+    @AppStorage(AppPreferences.opus45ThinkingEffortKey) private var opus45ThinkingEffort = AppPreferences.defaultOpus45ThinkingEffort
     @AppStorage(AppPreferences.sonnet46ThinkingEffortKey) private var sonnet46ThinkingEffort = AppPreferences.defaultSonnet46ThinkingEffort
     @AppStorage(AppPreferences.gpt53CodexReasoningEffortKey) private var gpt53CodexReasoningEffort = AppPreferences.defaultGpt53CodexReasoningEffort
     @AppStorage(AppPreferences.gpt54ReasoningEffortKey) private var gpt54ReasoningEffort = AppPreferences.defaultGpt54ReasoningEffort
@@ -532,6 +534,10 @@ struct SettingsView: View {
     @State private var claudeModelsExpanded = true
     @State private var codexModelsExpanded = true
     @State private var geminiModelsExpanded = true
+    @State private var opus47EffortExpanded = false
+    @State private var opus46EffortExpanded = false
+    @State private var opus45EffortExpanded = false
+    @State private var sonnet46EffortExpanded = false
     private let claudeEffortSelectionColor = Color(red: 0xD9/255, green: 0x77/255, blue: 0x57/255)
     private let codexEffortSelectionColor = Color(red: 0x74/255, green: 0xAA/255, blue: 0x9C/255)
     private let geminiEffortSelectionColor = Color(red: 0x42/255, green: 0x85/255, blue: 0xF4/255)
@@ -820,17 +826,33 @@ struct SettingsView: View {
                                             sonnet46ThinkingEffort = "max"
                                         }
                                     }
-                                effortPickerRow(
+                                collapsibleEffortPickerRow(
                                     "Opus 4.7 thinking effort",
                                     selection: $opus47ThinkingEffort,
                                     options: ["low", "medium", "high", "xhigh", "max"],
-                                    tint: claudeEffortSelectionColor
+                                    tint: claudeEffortSelectionColor,
+                                    isExpanded: $opus47EffortExpanded
                                 )
-                                effortPickerRow(
+                                collapsibleEffortPickerRow(
+                                    "Opus 4.6 thinking effort",
+                                    selection: $opus46ThinkingEffort,
+                                    options: ["low", "medium", "high", "max"],
+                                    tint: claudeEffortSelectionColor,
+                                    isExpanded: $opus46EffortExpanded
+                                )
+                                collapsibleEffortPickerRow(
+                                    "Opus 4.5 thinking effort",
+                                    selection: $opus45ThinkingEffort,
+                                    options: ["low", "medium", "high", "max"],
+                                    tint: claudeEffortSelectionColor,
+                                    isExpanded: $opus45EffortExpanded
+                                )
+                                collapsibleEffortPickerRow(
                                     "Sonnet 4.6 thinking effort",
                                     selection: $sonnet46ThinkingEffort,
                                     options: ["low", "medium", "high", "max"],
                                     tint: claudeEffortSelectionColor,
+                                    isExpanded: $sonnet46EffortExpanded,
                                     overrideBadge: claudeMaxBudgetMode ? "MAX MODE" : nil
                                 )
                                 .disabled(claudeMaxBudgetMode)
@@ -1130,6 +1152,74 @@ struct SettingsView: View {
         }
         .padding(.vertical, 2)
     }
+
+    /// A collapsible variant of `effortPickerRow` that shows only the title + current
+    /// selection badge when collapsed. Tapping the header toggles the picker visibility.
+    @ViewBuilder
+    private func collapsibleEffortPickerRow(
+        _ title: String,
+        selection: Binding<String>,
+        options: [String],
+        tint: Color,
+        isExpanded: Binding<Bool>,
+        overrideBadge: String? = nil
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.wrappedValue.toggle()
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: isExpanded.wrappedValue ? "chevron.down" : "chevron.right")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    Text(title)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    if let badge = overrideBadge {
+                        Text(badge)
+                            .font(.system(size: 8, weight: .bold, design: .monospaced))
+                            .tracking(0.8)
+                            .foregroundColor(Color(red: 0.9, green: 0.15, blue: 0.1))
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            .background(
+                                RoundedRectangle(cornerRadius: 3)
+                                    .stroke(Color(red: 0.9, green: 0.15, blue: 0.1).opacity(0.5), lineWidth: 1)
+                            )
+                    }
+                    Spacer()
+                    Text(selection.wrappedValue)
+                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                        .foregroundColor(tint)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .stroke(tint.opacity(0.4), lineWidth: 1)
+                        )
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(title)
+            .accessibilityValue(selection.wrappedValue)
+            .accessibilityHint(isExpanded.wrappedValue ? "Collapse effort picker" : "Expand effort picker")
+
+            if isExpanded.wrappedValue {
+                Picker("", selection: selection) {
+                    ForEach(options, id: \.self) { option in
+                        Text(option).tag(option)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .tint(tint)
+                .labelsHidden()
+            }
+        }
+        .padding(.vertical, 2)
+    }
     
     private func toggleAccountDisabled(_ account: AuthAccount) {
         if authManager.toggleAccountDisabled(account) {
@@ -1241,10 +1331,8 @@ struct SettingsView: View {
     // MARK: - Factory Custom Models
 
     /// Ids retired by prior releases. Removed from `customModels` during Apply/Re-apply
-    /// so users don't end up with stale entries (e.g. `Opus 4.6`) next to the current ones.
-    private static let legacyDroidProxyModelIds: Set<String> = [
-        "custom:droidproxy:opus-4-6"
-    ]
+    /// so users don't end up with stale entries next to the current ones.
+    private static let legacyDroidProxyModelIds: Set<String> = []
 
     private static let droidProxyModels: [[String: Any]] = [
         [
@@ -1254,6 +1342,26 @@ struct SettingsView: View {
             "apiKey": "dummy-not-used",
             "displayName": "DroidProxy: Opus 4.7",
             "maxOutputTokens": 128000,
+            "noImageSupport": false,
+            "provider": "anthropic"
+        ],
+        [
+            "model": "claude-opus-4-6",
+            "id": "custom:droidproxy:opus-4-6",
+            "baseUrl": "http://localhost:8317",
+            "apiKey": "dummy-not-used",
+            "displayName": "DroidProxy: Opus 4.6",
+            "maxOutputTokens": 128000,
+            "noImageSupport": false,
+            "provider": "anthropic"
+        ],
+        [
+            "model": "claude-opus-4-5-20251101",
+            "id": "custom:droidproxy:opus-4-5",
+            "baseUrl": "http://localhost:8317",
+            "apiKey": "dummy-not-used",
+            "displayName": "DroidProxy: Opus 4.5",
+            "maxOutputTokens": 64000,
             "noImageSupport": false,
             "provider": "anthropic"
         ],

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -127,7 +127,7 @@ struct MaxBudgetToggleView: View {
                         .font(.system(size: 10, weight: .bold, design: .monospaced))
                         .tracking(0.8)
                         .foregroundColor(isOn ? dangerRed : .gray.opacity(0.6))
-                    Text("Sonnet 4.6 only · max budget_tokens + effort")
+                    Text("Opus 4.6 + Sonnet 4.6 · max budget_tokens + effort")
                         .font(.system(size: 9))
                         .foregroundColor(.gray.opacity(0.5))
                 }
@@ -275,7 +275,7 @@ struct MaxBudgetToggleView: View {
                 }
             }
         }
-        .help("Overrides the Sonnet 4.6 effort slider with classic extended thinking (budget_tokens=63999, effort=max). Opus 4.7 keeps its own slider setting — max mode does not affect it. Ignition is cheap, fuel is not.")
+        .help("Overrides Opus 4.6 and Sonnet 4.6 effort sliders with classic extended thinking (budget_tokens=63999, effort=max). Opus 4.7 keeps its own slider setting — max mode does not affect it. Ignition is cheap, fuel is not.")
     }
 }
 
@@ -823,6 +823,7 @@ struct SettingsView: View {
                                     .onChange(of: claudeMaxBudgetMode) { enabled in
                                         if enabled {
                                             showingMaxBudgetWarning = true
+                                            opus46ThinkingEffort = "max"
                                             sonnet46ThinkingEffort = "max"
                                         }
                                     }
@@ -838,8 +839,11 @@ struct SettingsView: View {
                                     selection: $opus46ThinkingEffort,
                                     options: ["low", "medium", "high", "max"],
                                     tint: claudeEffortSelectionColor,
-                                    isExpanded: $opus46EffortExpanded
+                                    isExpanded: $opus46EffortExpanded,
+                                    overrideBadge: claudeMaxBudgetMode ? "MAX MODE" : nil
                                 )
+                                .disabled(claudeMaxBudgetMode)
+                                .opacity(claudeMaxBudgetMode ? 0.45 : 1.0)
                                 collapsibleEffortPickerRow(
                                     "Opus 4.5 thinking effort",
                                     selection: $opus45ThinkingEffort,
@@ -1113,7 +1117,7 @@ struct SettingsView: View {
         .alert("⚠️ MAX BUDGET MODE", isPresented: $showingMaxBudgetWarning) {
             Button("Engage", role: .cancel) { }
         } message: {
-            Text("Sonnet 4.6 requests will bypass its effort slider and revert to classic extended thinking with maximum budget_tokens and effort=max. Opus 4.7 keeps its own slider — Max Budget Mode does not apply to it. Sonnet will burn through your quota fast.")
+            Text("Opus 4.6 and Sonnet 4.6 requests will bypass their effort sliders and revert to classic extended thinking with maximum budget_tokens and effort=max. Opus 4.7 keeps its own slider — Max Budget Mode does not apply to it. These requests will burn through your quota fast.")
         }
     }
 

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -7,6 +7,11 @@ import Network
  Current behavior:
  - Requests whose `model` contains `opus-4-7` receive `thinking: {"type":"adaptive"}`
    plus `output_config.effort` from `AppPreferences.opus47ThinkingEffort`
+ - Requests whose `model` contains `opus-4-6` receive `thinking: {"type":"adaptive"}`
+   plus `output_config.effort` from `AppPreferences.opus46ThinkingEffort`
+ - Requests whose `model` contains `opus-4-5` receive classic
+   `thinking: {"type":"enabled","budget_tokens":N}` mapped from
+   `AppPreferences.opus45ThinkingEffort` (Opus 4.5 does not support adaptive thinking).
  - Requests whose `model` contains `sonnet-4-6` receive `thinking: {"type":"adaptive"}`
    plus `output_config.effort` from `AppPreferences.sonnet46ThinkingEffort`
  - Requests whose `model` is exactly `gpt-5.3-codex` receive `reasoning: {"effort":"..."}`
@@ -327,6 +332,11 @@ class ThinkingProxy {
             return result
         }
 
+        // Opus 4.5 uses classic extended thinking (budget_tokens) — it does not support adaptive.
+        if isOpus45Model(model) {
+            return processOpus45ClassicThinking(jsonString: jsonString, json: json, model: model)
+        }
+
         guard let effort = claudeAdaptiveThinkingEffort(for: model) else {
             return nil
         }
@@ -413,10 +423,63 @@ class ThinkingProxy {
         if model.contains("opus-4-7") {
             return AppPreferences.opus47ThinkingEffort
         }
+        if model.contains("opus-4-6") {
+            return AppPreferences.opus46ThinkingEffort
+        }
         if model.contains("sonnet-4-6") {
             return AppPreferences.sonnet46ThinkingEffort
         }
         return nil
+    }
+
+    /// Matches Opus 4.5 (`claude-opus-4-5`, `gemini-claude-opus-4-5`, date-suffixed variants)
+    /// without also matching Opus 4.5x variants that do not exist today.
+    private func isOpus45Model(_ model: String) -> Bool {
+        guard model.starts(with: "claude-") || model.starts(with: "gemini-claude-") else {
+            return false
+        }
+        return model.contains("opus-4-5")
+    }
+
+    /// Opus 4.5 does not accept adaptive thinking. It requires the legacy
+    /// `thinking: {type: "enabled", budget_tokens: N}` shape, where
+    /// `budget_tokens < max_tokens` (min 1024).
+    private func processOpus45ClassicThinking(jsonString: String, json: [String: Any], model: String) -> String? {
+        let effort = AppPreferences.opus45ThinkingEffort
+        let (budgetTokens, maxTokens) = opus45ClassicBudget(for: effort)
+
+        var result = jsonString
+
+        result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "stream",
+                                          fieldValue: "true", existsInJSON: json["stream"] != nil)
+        result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "max_tokens",
+                                          fieldValue: "\(maxTokens)",
+                                          existsInJSON: json["max_tokens"] != nil)
+        result = replaceOrInjectJSONField(in: result, afterKey: "max_tokens",
+                                          fieldName: "thinking",
+                                          fieldValue: "{\"type\":\"enabled\",\"budget_tokens\":\(budgetTokens)}",
+                                          existsInJSON: json["thinking"] != nil)
+
+        NSLog("[ThinkingProxy] Injected Opus 4.5 classic thinking for '\(model)' effort=\(effort) budget_tokens=\(budgetTokens) max_tokens=\(maxTokens)")
+        ThinkingProxy.fileLog("INJECTED Opus 4.5 classic thinking: effort=\(effort) budget_tokens=\(budgetTokens) max_tokens=\(maxTokens) for model \(model)")
+        return result
+    }
+
+    /// Maps effort levels to (budget_tokens, max_tokens) pairs for Opus 4.5.
+    /// Opus 4.5 supports `max_tokens` up to 64000 and requires budget_tokens < max_tokens.
+    private func opus45ClassicBudget(for effort: String) -> (Int, Int) {
+        switch effort {
+        case "low":
+            return (4000, 16000)
+        case "medium":
+            return (16000, 32000)
+        case "high":
+            return (32000, 48000)
+        case "max":
+            return (48000, 64000)
+        default:
+            return (32000, 48000)
+        }
     }
 
     private func geminiThinkingLevel(for model: String) -> String? {

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -346,8 +346,9 @@ class ThinkingProxy {
         result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "stream",
                                           fieldValue: "true", existsInJSON: json["stream"] != nil)
 
-        if AppPreferences.claudeMaxBudgetMode && model.contains("sonnet-4-6") {
-            // Sonnet 4.6 classic extended-thinking override. budget_tokens must be strictly less
+        if AppPreferences.claudeMaxBudgetMode &&
+            (model.contains("sonnet-4-6") || model.contains("opus-4-6")) {
+            // Sonnet 4.6 / Opus 4.6 classic extended-thinking override. budget_tokens must be strictly less
             // than max_tokens (min 1024). Request body changes stay inside the adaptive-thinking
             // window this path already controls.
             let maxTokens = 64000
@@ -397,21 +398,15 @@ class ThinkingProxy {
         return injectJSONField(in: json, afterKey: afterKey, fieldName: fieldName, fieldValue: fieldValue)
     }
 
-    /// Replaces the value of an existing JSON field using regex.
+    /// Replaces the value of an existing top-level JSON field.
     private func replaceJSONFieldValue(in json: String, fieldName: String, newValue: String) -> String {
-        let escapedKey = NSRegularExpression.escapedPattern(for: fieldName)
-        let valuePattern = "(?:\"(?:[^\"\\\\]|\\\\.)*\"|\\-?\\d+(?:\\.\\d+)?|\\{[^}]*\\}|\\[[^\\]]*\\]|true|false|null)"
-        let pattern = "(\"\(escapedKey)\"\\s*:\\s*)\(valuePattern)"
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: json, range: NSRange(json.startIndex..., in: json)),
-              let matchRange = Range(match.range, in: json),
-              let prefixRange = Range(match.range(at: 1), in: json) else {
+        guard let location = findTopLevelFieldLocation(in: json, key: fieldName) else {
             NSLog("[ThinkingProxy] Warning: Could not find key '\(fieldName)' for value replacement")
             return json
         }
+
         var result = json
-        let prefix = String(json[prefixRange])
-        result.replaceSubrange(matchRange, with: "\(prefix)\(newValue)")
+        result.replaceSubrange(location.valueRange, with: newValue)
         return result
     }
 
@@ -533,33 +528,246 @@ class ThinkingProxy {
     }
 
     // MARK: - Surgical JSON string helpers
-    // These use regex to modify specific fields in-place, preserving the original JSON structure
-    // and key ordering. This is critical because JSONSerialization.data() reorders keys
-    // alphabetically, which breaks Anthropic's prompt cache matching.
+    // These scan the top-level JSON object and modify specific fields in-place, preserving
+    // the original JSON structure and key ordering. This is critical because
+    // JSONSerialization.data() reorders keys alphabetically, which breaks Anthropic's
+    // prompt cache matching.
 
     /// Injects a new JSON field after a given key's value in the JSON string.
-    /// Uses `Range(_:in:)` to convert the NSRegularExpression UTF-16 range into a
-    /// `String.Index`. Mixing UTF-16 offsets with `String.index(_:offsetBy:)`
-    /// (which walks Characters) traps on any body containing non-ASCII graphemes.
+    /// Only matches keys at the top-level request object so nested assistant content
+    /// blocks remain unchanged.
     private func injectJSONField(in json: String, afterKey: String, fieldName: String, fieldValue: String) -> String {
-        let escapedKey = NSRegularExpression.escapedPattern(for: afterKey)
-        let valuePattern = "(?:\"(?:[^\"\\\\]|\\\\.)*\"|\\-?\\d+(?:\\.\\d+)?|\\{[^}]*\\}|\\[[^\\]]*\\]|true|false|null)"
-        let pattern = "\"\(escapedKey)\"\\s*:\\s*\(valuePattern)"
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: json, range: NSRange(json.startIndex..., in: json)),
-              let matchRange = Range(match.range, in: json) else {
+        guard let location = findTopLevelFieldLocation(in: json, key: afterKey) else {
             NSLog("[ThinkingProxy] Warning: Could not find key '\(afterKey)' for field injection")
             return json
         }
+
         var result = json
-        result.insert(contentsOf: ",\"\(fieldName)\":\(fieldValue)", at: matchRange.upperBound)
+        result.insert(contentsOf: ",\"\(fieldName)\":\(fieldValue)", at: location.pairRange.upperBound)
         return result
+    }
+
+    private struct TopLevelFieldLocation {
+        let pairRange: Range<String.Index>
+        let valueRange: Range<String.Index>
+    }
+
+    private func findTopLevelFieldLocation(in json: String, key targetKey: String) -> TopLevelFieldLocation? {
+        guard var index = firstNonWhitespaceIndex(in: json, from: json.startIndex),
+              json[index] == "{" else {
+            return nil
+        }
+
+        index = json.index(after: index)
+
+        while true {
+            guard let keyStart = firstNonWhitespaceIndex(in: json, from: index) else {
+                return nil
+            }
+
+            let token = json[keyStart]
+            if token == "}" {
+                return nil
+            }
+            guard token == "\"" else {
+                return nil
+            }
+
+            guard let (key, keyEnd) = parseJSONStringToken(in: json, startingAt: keyStart),
+                  let colonIndex = firstNonWhitespaceIndex(in: json, from: keyEnd),
+                  json[colonIndex] == ":" else {
+                return nil
+            }
+
+            let afterColon = json.index(after: colonIndex)
+            guard let valueStart = firstNonWhitespaceIndex(in: json, from: afterColon),
+                  let valueEnd = consumeJSONValue(in: json, startingAt: valueStart) else {
+                return nil
+            }
+
+            if key == targetKey {
+                return TopLevelFieldLocation(pairRange: keyStart..<valueEnd,
+                                             valueRange: valueStart..<valueEnd)
+            }
+
+            guard let delimiterIndex = firstNonWhitespaceIndex(in: json, from: valueEnd) else {
+                return nil
+            }
+
+            let delimiter = json[delimiterIndex]
+            if delimiter == "," {
+                index = json.index(after: delimiterIndex)
+                continue
+            }
+            if delimiter == "}" {
+                return nil
+            }
+            return nil
+        }
+    }
+
+    private func firstNonWhitespaceIndex(in json: String, from start: String.Index) -> String.Index? {
+        var index = start
+        while index < json.endIndex, json[index].isWhitespace {
+            index = json.index(after: index)
+        }
+        return index < json.endIndex ? index : nil
+    }
+
+    private func parseJSONStringToken(in json: String, startingAt startQuote: String.Index) -> (String, String.Index)? {
+        guard json[startQuote] == "\"" else {
+            return nil
+        }
+
+        var index = json.index(after: startQuote)
+        var escaped = false
+
+        while index < json.endIndex {
+            let char = json[index]
+            if escaped {
+                escaped = false
+            } else if char == "\\" {
+                escaped = true
+            } else if char == "\"" {
+                let value = String(json[json.index(after: startQuote)..<index])
+                return (value, json.index(after: index))
+            }
+            index = json.index(after: index)
+        }
+
+        return nil
+    }
+
+    private func consumeJSONValue(in json: String, startingAt start: String.Index) -> String.Index? {
+        guard start < json.endIndex else {
+            return nil
+        }
+
+        let first = json[start]
+        if first == "\"" {
+            return parseJSONStringToken(in: json, startingAt: start)?.1
+        }
+
+        if first == "{" || first == "[" {
+            return consumeCompositeJSONValue(in: json, startingAt: start)
+        }
+
+        var index = start
+        while index < json.endIndex {
+            let char = json[index]
+            if char == "," || char == "}" || char == "]" || char.isWhitespace {
+                break
+            }
+            index = json.index(after: index)
+        }
+
+        return index > start ? index : nil
+    }
+
+    private func consumeCompositeJSONValue(in json: String, startingAt start: String.Index) -> String.Index? {
+        var index = start
+        var depth = 0
+        var inString = false
+        var escaped = false
+
+        while index < json.endIndex {
+            let char = json[index]
+
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if char == "\\" {
+                    escaped = true
+                } else if char == "\"" {
+                    inString = false
+                }
+            } else {
+                if char == "\"" {
+                    inString = true
+                } else if char == "{" || char == "[" {
+                    depth += 1
+                } else if char == "}" || char == "]" {
+                    depth -= 1
+                    if depth == 0 {
+                        return json.index(after: index)
+                    }
+                    if depth < 0 {
+                        return nil
+                    }
+                }
+            }
+
+            index = json.index(after: index)
+        }
+
+        return nil
     }
 
     private static let fastTierEligibleResponsePaths: Set<String> = [
         "/v1/responses",
         "/api/v1/responses"
     ]
+
+    private static let ampProviderToolRewritePattern = "\"name\"\\s*:\\s*\"bash\""
+    private static let ampProviderRewriteCarryLength = 31
+
+    private final class AmpProviderRewriteState {
+        var carry = ""
+    }
+
+    private func shouldNormalizeAmpProviderResponse(for path: String) -> Bool {
+        let normalizedPath = path.split(separator: "?").first.map(String.init) ?? path
+        return normalizedPath.starts(with: "/api/provider/")
+    }
+
+    private func normalizeAmpProviderResponseChunk(_ data: Data,
+                                                   rewriteState: AmpProviderRewriteState,
+                                                   isComplete: Bool) -> Data {
+        let carryPrefix = rewriteState.carry
+        rewriteState.carry = ""
+
+        guard let chunk = String(data: data, encoding: .utf8) else {
+            if carryPrefix.isEmpty {
+                return data
+            }
+            var passthrough = Data(carryPrefix.utf8)
+            passthrough.append(data)
+            return passthrough
+        }
+
+        var combined = carryPrefix + chunk
+        let beforeRewrite = combined
+        combined = combined.replacingOccurrences(of: Self.ampProviderToolRewritePattern,
+                                                 with: "\"name\":\"Bash\"",
+                                                 options: .regularExpression)
+        if combined != beforeRewrite {
+            NSLog("[ThinkingProxy] Normalized Amp provider tool name(s) in response chunk")
+        }
+
+        guard !isComplete else {
+            return Data(combined.utf8)
+        }
+
+        let carryLength = min(Self.ampProviderRewriteCarryLength, combined.count)
+        if carryLength == combined.count {
+            rewriteState.carry = combined
+            return Data()
+        }
+
+        let carryStart = combined.index(combined.endIndex, offsetBy: -carryLength)
+        let output = String(combined[..<carryStart])
+        rewriteState.carry = String(combined[carryStart...])
+        return Data(output.utf8)
+    }
+
+    private func flushNormalizedResponseCarry(_ rewriteState: AmpProviderRewriteState?) -> Data? {
+        guard let rewriteState, !rewriteState.carry.isEmpty else {
+            return nil
+        }
+        let carry = rewriteState.carry
+        rewriteState.carry = ""
+        return Data(carry.utf8)
+    }
 
     private func processOpenAIFastMode(jsonString: String, path: String) -> String? {
         let normalizedPath = path.split(separator: "?").first.map(String.init) ?? path
@@ -794,12 +1002,16 @@ class ThinkingProxy {
                             originalConnection.cancel()
                         } else {
                             // Receive response from CLIProxyAPI (with 404 retry capability)
+                            let normalizeAmpProviderResponse = self.shouldNormalizeAmpProviderResponse(for: path)
                             if retryWithApiPrefix {
                                 self.receiveResponseWith404Retry(from: targetConnection, originalConnection: originalConnection, 
                                                                  method: method, path: path, version: version, 
-                                                                 headers: headers, body: body)
+                                                                 headers: headers, body: body,
+                                                                 normalizeAmpProviderResponse: normalizeAmpProviderResponse)
                             } else {
-                                self.receiveResponse(from: targetConnection, originalConnection: originalConnection)
+                                self.receiveResponse(from: targetConnection,
+                                                     originalConnection: originalConnection,
+                                                     normalizeAmpProviderResponse: normalizeAmpProviderResponse)
                             }
                         }
                     }))
@@ -823,7 +1035,9 @@ class ThinkingProxy {
      */
     private func receiveResponseWith404Retry(from targetConnection: NWConnection, originalConnection: NWConnection, 
                                              method: String, path: String, version: String, 
-                                             headers: [(String, String)], body: String) {
+                                             headers: [(String, String)], body: String,
+                                             normalizeAmpProviderResponse: Bool) {
+        let rewriteState = normalizeAmpProviderResponse ? AmpProviderRewriteState() : nil
         targetConnection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
             guard let self = self else { return }
             
@@ -862,7 +1076,17 @@ class ThinkingProxy {
                 }
                 
                 // Not a 404 or already has /api/, forward response as-is
-                originalConnection.send(content: data, completion: .contentProcessed({ sendError in
+                var outboundData = data
+                if let rewriteState {
+                    outboundData = self.normalizeAmpProviderResponseChunk(data, rewriteState: rewriteState, isComplete: isComplete)
+                }
+
+                if outboundData.isEmpty && !isComplete {
+                    self.streamNextChunk(from: targetConnection, to: originalConnection, rewriteState: rewriteState)
+                    return
+                }
+
+                originalConnection.send(content: outboundData, completion: .contentProcessed({ sendError in
                     if let sendError = sendError {
                         NSLog("[ThinkingProxy] Send error: \(sendError)")
                     }
@@ -874,14 +1098,22 @@ class ThinkingProxy {
                         }))
                     } else {
                         // Continue streaming
-                        self.streamNextChunk(from: targetConnection, to: originalConnection)
+                        self.streamNextChunk(from: targetConnection, to: originalConnection, rewriteState: rewriteState)
                     }
                 }))
             } else if isComplete {
                 targetConnection.cancel()
-                originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
-                    originalConnection.cancel()
-                }))
+                if let carryData = self.flushNormalizedResponseCarry(rewriteState), !carryData.isEmpty {
+                    originalConnection.send(content: carryData, completion: .contentProcessed({ _ in
+                        originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
+                            originalConnection.cancel()
+                        }))
+                    }))
+                } else {
+                    originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
+                        originalConnection.cancel()
+                    }))
+                }
             }
         }
     }
@@ -890,15 +1122,20 @@ class ThinkingProxy {
      Receives response from CLIProxyAPI
      Starts the streaming loop for response data
      */
-    private func receiveResponse(from targetConnection: NWConnection, originalConnection: NWConnection) {
+    private func receiveResponse(from targetConnection: NWConnection,
+                                 originalConnection: NWConnection,
+                                 normalizeAmpProviderResponse: Bool = false) {
+        let rewriteState = normalizeAmpProviderResponse ? AmpProviderRewriteState() : nil
         // Start the streaming loop
-        streamNextChunk(from: targetConnection, to: originalConnection)
+        streamNextChunk(from: targetConnection, to: originalConnection, rewriteState: rewriteState)
     }
     
     /**
      Streams response chunks iteratively (uses async scheduling instead of recursion to avoid stack buildup)
      */
-    private func streamNextChunk(from targetConnection: NWConnection, to originalConnection: NWConnection) {
+    private func streamNextChunk(from targetConnection: NWConnection,
+                                 to originalConnection: NWConnection,
+                                 rewriteState: AmpProviderRewriteState? = nil) {
         targetConnection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
             guard let self = self else { return }
             
@@ -910,8 +1147,18 @@ class ThinkingProxy {
             }
             
             if let data = data, !data.isEmpty {
+                var outboundData = data
+                if let rewriteState {
+                    outboundData = self.normalizeAmpProviderResponseChunk(data, rewriteState: rewriteState, isComplete: isComplete)
+                }
+
+                if outboundData.isEmpty && !isComplete {
+                    self.streamNextChunk(from: targetConnection, to: originalConnection, rewriteState: rewriteState)
+                    return
+                }
+
                 // Forward response chunk to original client
-                originalConnection.send(content: data, completion: .contentProcessed({ sendError in
+                originalConnection.send(content: outboundData, completion: .contentProcessed({ sendError in
                     if let sendError = sendError {
                         NSLog("[ThinkingProxy] Send response error: \(sendError)")
                     }
@@ -924,15 +1171,24 @@ class ThinkingProxy {
                         }))
                     } else {
                         // Schedule next iteration of the streaming loop
-                        self.streamNextChunk(from: targetConnection, to: originalConnection)
+                        self.streamNextChunk(from: targetConnection, to: originalConnection, rewriteState: rewriteState)
                     }
                 }))
             } else if isComplete {
                 targetConnection.cancel()
-                // Always close client connection - no keep-alive/pipelining support
-                originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
-                    originalConnection.cancel()
-                }))
+                if let carryData = self.flushNormalizedResponseCarry(rewriteState), !carryData.isEmpty {
+                    originalConnection.send(content: carryData, completion: .contentProcessed({ _ in
+                        // Always close client connection - no keep-alive/pipelining support
+                        originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
+                            originalConnection.cancel()
+                        }))
+                    }))
+                } else {
+                    // Always close client connection - no keep-alive/pipelining support
+                    originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
+                        originalConnection.cancel()
+                    }))
+                }
             }
         }
     }

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -433,12 +433,17 @@ class ThinkingProxy {
     }
 
     /// Matches Opus 4.5 (`claude-opus-4-5`, `gemini-claude-opus-4-5`, date-suffixed variants)
-    /// without also matching Opus 4.5x variants that do not exist today.
+    /// without also matching Opus 4.5x variants like `opus-4-50` or `opus-4-5x`.
+    /// The `opus-4-5` token must be at the end of the string or followed by a `-` delimiter.
     private func isOpus45Model(_ model: String) -> Bool {
         guard model.starts(with: "claude-") || model.starts(with: "gemini-claude-") else {
             return false
         }
-        return model.contains("opus-4-5")
+        guard let range = model.range(of: "opus-4-5") else {
+            return false
+        }
+        let suffix = model[range.upperBound...]
+        return suffix.isEmpty || suffix.hasPrefix("-")
     }
 
     /// Opus 4.5 does not accept adaptive thinking. It requires the legacy


### PR DESCRIPTION
## Summary

Brings back Claude Opus 4.6 and introduces Opus 4.5 while keeping Opus 4.7 as the flagship. Users now get per-model effort pickers for all three Opus versions plus Sonnet 4.6.

## Model handling

| Model | Thinking mode | Effort source |
|---|---|---|
| Opus 4.7 | `thinking.type=adaptive` + `output_config.effort` | `opus47ThinkingEffort` (existing) |
| Opus 4.6 | `thinking.type=adaptive` + `output_config.effort` | `opus46ThinkingEffort` (new, default `max`) |
| Opus 4.5 | `thinking.type=enabled` + `budget_tokens` | `opus45ThinkingEffort` (new, default `high`) |
| Sonnet 4.6 | `thinking.type=adaptive` + `output_config.effort` | `sonnet46ThinkingEffort` (existing) |

Opus 4.5 doesn't support adaptive thinking ([Anthropic docs](https://docs.anthropic.com/en/docs/build-with-claude/adaptive-thinking)), so `ThinkingProxy` falls back to the classic extended-thinking shape. Effort maps to `(budget_tokens, max_tokens)` pairs: low=4k/16k, medium=16k/32k, high=32k/48k, max=48k/64k.

## UI

To keep the settings list from ballooning with four Claude rows, pickers are now collapsed by default. The header shows `Title · chevron · [current value pill]`; expanding reveals the segmented picker. Applies to all four Claude effort rows.

## Factory custom models

Added:
- `custom:droidproxy:opus-4-6` → `claude-opus-4-6`
- `custom:droidproxy:opus-4-5` → `claude-opus-4-5-20251101` (dated form — CLIProxyAPIPlus rejects the un-dated alias with `unknown provider for model claude-opus-4-5`)

`legacyDroidProxyModelIds` is emptied since `opus-4-6` is an active entry again. Users need to re-apply custom models in Settings to pick up the new entries.

## Testing

- `cd src && swift build` → clean (only pre-existing warnings)
- Verified Opus 4.7, 4.6, and 4.5 requests end-to-end through the local proxy
