### PR TITLE
fix: switch Gemini models to anthropic provider and strip doubled /v1 prefix

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -65,7 +65,7 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
       "displayName": "DroidProxy: Gemini 3.1 Pro",
       "maxOutputTokens": 65536,
       "noImageSupport": false,
-      "provider": "google"
+      "provider": "anthropic"
     },
     {
       "model": "gemini-3-flash-preview",
@@ -76,12 +76,12 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
       "displayName": "DroidProxy: Gemini 3 Flash",
       "maxOutputTokens": 65536,
       "noImageSupport": false,
-      "provider": "google"
+      "provider": "anthropic"
     }
 ]
 ```
 
-Use the standard Claude and Codex model aliases in the `model` field. Claude entries use `provider: "anthropic"` with `http://localhost:8317`; GPT/Codex and Gemini entries use `provider: "openai"` with `http://localhost:8317/v1`. DroidProxy applies Claude adaptive thinking, Codex reasoning effort, and Gemini thinking levels based on the selected model and the effort/level setting in DroidProxy itself.
+Use the standard Claude and Codex model aliases in the `model` field. Claude and Gemini entries use `provider: "anthropic"` with `http://localhost:8317`; GPT/Codex entries use `provider: "openai"` with `http://localhost:8317/v1`. DroidProxy applies Claude adaptive thinking, Codex reasoning effort, and Gemini thinking levels based on the selected model and the effort/level setting in DroidProxy itself.
 
 ## 3. Configure Thinking Effort
 

--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -11,6 +11,7 @@ enum AppPreferences {
     static let gpt54FastModeKey = "gpt54FastMode"
     static let gemini31ProThinkingLevelKey = "gemini31ProThinkingLevel"
     static let gemini3FlashThinkingLevelKey = "gemini3FlashThinkingLevel"
+    static let geminiV1PathFixKey = "geminiV1PathFix"
     static let claudeMaxBudgetModeKey = "claudeMaxBudgetMode"
     static let allowRemoteKey = "allowRemote"
     static let secretKeyKey = "secretKey"
@@ -26,6 +27,7 @@ enum AppPreferences {
     static let defaultGpt54FastMode = false
     static let defaultGemini31ProThinkingLevel = "high"
     static let defaultGemini3FlashThinkingLevel = "high"
+    static let defaultGeminiV1PathFix = true
     static let defaultClaudeMaxBudgetMode = false
     static let defaultAllowRemote = false
     static let defaultSecretKey = ""
@@ -92,6 +94,14 @@ enum AppPreferences {
             return defaultGemini3FlashThinkingLevel
         }
         return defaults.string(forKey: gemini3FlashThinkingLevelKey) ?? defaultGemini3FlashThinkingLevel
+    }
+
+    static var geminiV1PathFix: Bool {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: geminiV1PathFixKey) != nil else {
+            return defaultGeminiV1PathFix
+        }
+        return defaults.bool(forKey: geminiV1PathFixKey)
     }
 
     static var claudeMaxBudgetMode: Bool {

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -516,6 +516,7 @@ struct SettingsView: View {
     @AppStorage(AppPreferences.gpt54FastModeKey) private var gpt54FastMode = AppPreferences.defaultGpt54FastMode
     @AppStorage(AppPreferences.gemini31ProThinkingLevelKey) private var gemini31ProThinkingLevel = AppPreferences.defaultGemini31ProThinkingLevel
     @AppStorage(AppPreferences.gemini3FlashThinkingLevelKey) private var gemini3FlashThinkingLevel = AppPreferences.defaultGemini3FlashThinkingLevel
+    @AppStorage(AppPreferences.geminiV1PathFixKey) private var geminiV1PathFix = AppPreferences.defaultGeminiV1PathFix
     @AppStorage(AppPreferences.allowRemoteKey) private var allowRemote = AppPreferences.defaultAllowRemote
     @AppStorage(AppPreferences.secretKeyKey) private var secretKey = AppPreferences.defaultSecretKey
     @AppStorage(AppPreferences.claudeMaxBudgetModeKey) private var claudeMaxBudgetMode = AppPreferences.defaultClaudeMaxBudgetMode
@@ -993,6 +994,12 @@ struct SettingsView: View {
                                     options: ["minimal", "low", "medium", "high"],
                                     tint: geminiEffortSelectionColor
                                 )
+                                Toggle("Fix factory-cli /v1/v1 path bug", isOn: $geminiV1PathFix)
+                                    .toggleStyle(.checkbox)
+                                    .font(.caption)
+                                    .tint(geminiEffortSelectionColor)
+                                    .help("factory-cli 0.105.1 sends POST /v1/v1/messages for custom Gemini models under provider=anthropic, causing first-turn tool calls to fail with 404. When enabled, DroidProxy rewrites /v1/v1/... back to /v1/... before forwarding.")
+                                    .padding(.vertical, 2)
                             }
                         }
                         .padding(.leading, 28)
@@ -1407,7 +1414,7 @@ struct SettingsView: View {
             "displayName": "DroidProxy: Gemini 3.1 Pro",
             "maxOutputTokens": 65536,
             "noImageSupport": false,
-            "provider": "google"
+            "provider": "anthropic"
         ],
         [
             "model": "gemini-3-flash-preview",
@@ -1417,7 +1424,7 @@ struct SettingsView: View {
             "displayName": "DroidProxy: Gemini 3 Flash",
             "maxOutputTokens": 65536,
             "noImageSupport": false,
-            "provider": "google"
+            "provider": "anthropic"
         ]
     ]
 

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -261,6 +261,24 @@ class ThinkingProxy {
             rewrittenPath = "/api" + path
             NSLog("[ThinkingProxy] Rewriting Amp provider path: \(path) -> \(rewrittenPath)")
         }
+
+        // Strip the doubled /v1 prefix that factory-cli 0.105.1 emits for custom
+        // Gemini models under provider=anthropic (first-turn requests hit
+        // /v1/v1/messages and 404, triggering tool-call retry loops).
+        // Gated by AppPreferences.geminiV1PathFix so users can disable it.
+        if AppPreferences.geminiV1PathFix {
+            if rewrittenPath.hasPrefix("/v1/v1/") {
+                let fixed = String(rewrittenPath.dropFirst(3)) // /v1/v1/messages -> /v1/messages
+                NSLog("[ThinkingProxy] Stripping doubled /v1 prefix: \(rewrittenPath) -> \(fixed)")
+                ThinkingProxy.fileLog("REWRITE PATH: \(rewrittenPath) -> \(fixed) (factory-cli /v1/v1 fix)")
+                rewrittenPath = fixed
+            } else if rewrittenPath.hasPrefix("/api/v1/v1/") {
+                let fixed = "/api" + String(rewrittenPath.dropFirst(7)) // /api/v1/v1/... -> /api/v1/...
+                NSLog("[ThinkingProxy] Stripping doubled /v1 prefix: \(rewrittenPath) -> \(fixed)")
+                ThinkingProxy.fileLog("REWRITE PATH: \(rewrittenPath) -> \(fixed) (factory-cli /v1/v1 fix)")
+                rewrittenPath = fixed
+            }
+        }
         
         // Check if this is an Amp management request (anything not targeting provider or /v1)
         // Note: /provider/ paths are already rewritten to /api/provider/ above


### PR DESCRIPTION
## Summary
- Switch Gemini 3.1 Pro and Gemini 3 Flash custom model entries from `provider: "google"` to `provider: "anthropic"` in `SETUP.md` and the `factoryCustomModels` array in `SettingsView.swift`, and update the surrounding SETUP.md prose to match.
- Add a `geminiV1PathFix` preference (default on) plus a checkbox in the Gemini settings pane to toggle it.
- In `ThinkingProxy`, strip the doubled `/v1` prefix (`/v1/v1/...` → `/v1/...`, `/api/v1/v1/...` → `/api/v1/...`) that factory-cli 0.105.1 emits for custom Gemini models under `provider=anthropic`, which otherwise 404s and triggers tool-call retry loops on the first turn.

## Breaking Changes
- Users with existing `~/.factory/settings.json` entries for the DroidProxy Gemini models on `provider: "google"` will need to re-apply the custom models (or edit the provider field) to pick up the new `anthropic` routing.

## Testing
- [ ] Apply custom models from DroidProxy Settings, confirm both Gemini entries in `~/.factory/settings.json` now use `provider: "anthropic"`.
- [ ] Run a first-turn tool call against Gemini 3.1 Pro in Factory with the toggle enabled and confirm no 404s on `/v1/v1/messages`.
- [ ] Disable the `Fix factory-cli /v1/v1 path bug` toggle and confirm the path rewrite is skipped (paths pass through unchanged).
- [ ] Verify Gemini thinking-level selectors still apply and non-Gemini providers (Claude, GPT/Codex) are unaffected.