### PR TITLE
ci(release): ship in-tree CLIProxyAPIPlus binary instead of re-downloading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,12 +66,22 @@ jobs:
           echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
           echo "Releasing v${VERSION} (build ${BUILD_NUMBER})"
 
-      - name: Resolve CLIProxyAPIPlus version
+      - name: Verify bundled CLIProxyAPIPlus
         id: cliproxy
         run: |
           set -euo pipefail
 
-          OUTPUT=$(src/Sources/Resources/cli-proxy-api-plus 2>&1 || true)
+          # Upstream router-for-me/CLIProxyAPIPlus was removed, so we ship the
+          # binary that's already committed at src/Sources/Resources/cli-proxy-api-plus
+          # instead of re-downloading it during the release build.
+          BIN="src/Sources/Resources/cli-proxy-api-plus"
+          if [ ! -f "$BIN" ]; then
+            echo "::error::Bundled CLIProxyAPIPlus binary missing at $BIN"
+            exit 1
+          fi
+          chmod +x "$BIN"
+
+          OUTPUT=$("$BIN" 2>&1 || true)
           VERSION=$(printf '%s\n' "$OUTPUT" | sed -nE 's/.*CLIProxyAPI Version: ([0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?)-plus,.*/\1/p' | head -n 1)
 
           if [ -z "$VERSION" ]; then
@@ -82,34 +92,7 @@ jobs:
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Bundled CLIProxyAPIPlus: $VERSION"
-
-      - name: Download CLIProxyAPIPlus for arm64
-        run: |
-          set -euo pipefail
-
-          VERSION="${{ steps.cliproxy.outputs.version }}"
-          TAG="v${VERSION}"
-          FILENAME="CLIProxyAPIPlus_${VERSION}_darwin_arm64.tar.gz"
-          URL="https://github.com/router-for-me/CLIProxyAPIPlus/releases/download/${TAG}/${FILENAME}"
-
-          echo "Downloading: $URL"
-          curl -L -f --retry 3 --retry-delay 5 -o cliproxy.tar.gz "$URL"
-
-          TEMP_DIR=$(mktemp -d)
-          trap 'rm -rf "$TEMP_DIR" cliproxy.tar.gz' EXIT
-
-          tar -xzf cliproxy.tar.gz -C "$TEMP_DIR"
-
-          BINARY=$(find "$TEMP_DIR" -type f \( -name "CLIProxyAPIPlus" -o -name "cli-proxy-api-plus" \) | head -n 1)
-          if [ -z "$BINARY" ]; then
-            echo "::error::Could not find binary in tarball"
-            find "$TEMP_DIR" -maxdepth 2 -type f -print
-            exit 1
-          fi
-
-          cp "$BINARY" src/Sources/Resources/cli-proxy-api-plus
-          chmod +x src/Sources/Resources/cli-proxy-api-plus
-          file src/Sources/Resources/cli-proxy-api-plus
+          file "$BIN"
 
       - name: Build app bundle
         env:


### PR DESCRIPTION
## Summary

The `Release` workflow has been failing because its "Download CLIProxyAPIPlus for arm64" step hits `https://github.com/router-for-me/CLIProxyAPIPlus/releases/download/v6.9.28-0/CLIProxyAPIPlus_6.9.28-0_darwin_arm64.tar.gz`, which now returns **404** — the upstream `router-for-me/CLIProxyAPIPlus` repo has been removed (the `router-for-me` org still exists, but only `CLIProxyAPI`, `CLIProxyAPIBusiness`, and a few other repos remain).

The latest failure: https://github.com/anand-92/droidproxy/actions/runs/24852341809 (triggered by #48 merging to `main`).

## Fix

The binary is **already committed in-tree** at `src/Sources/Resources/cli-proxy-api-plus` (49 MB, tracked directly by git, not LFS) and `create-app-bundle.sh` already copies everything from `Sources/Resources/*` into the `.app` bundle with a hard-fail guard if the binary is missing. The old download step was just overwriting that committed binary with a fresh copy — useful when the now-broken `Update CLIProxyAPIPlus` cron was working, but dead weight now that upstream is gone.

This PR replaces the old **Resolve → Download** two-step with a single **"Verify bundled CLIProxyAPIPlus"** step that:
- Asserts the binary exists
- Boots it to confirm it runs
- Parses the `CLIProxyAPI Version: X.Y.Z-plus` string for logging / appcast context

No behavior change for the shipped app — `create-app-bundle.sh`, signing, notarization, and Sparkle signing all continue to use the exact same committed binary.

## Out of scope

The `Update CLIProxyAPIPlus` cron (`.github/workflows/update-cliproxyapi.yml`) is also broken for the same reason but left untouched per request — you'll investigate upstream manually to decide whether to retarget to `router-for-me/CLIProxyAPIBusiness` (v2026.13.0, different binary name `cpab_*`), fall back to non-Plus `router-for-me/CLIProxyAPI` (v6.9.35, loses Plus features), or disable the cron.

## Testing

After this merges, re-run the Release workflow via `workflow_dispatch` to cut v1.8.9 with the GPT 5.5 changes from #48.