### PR TITLE
fix(deps): pin uuid to ^14 via npm overrides to patch GHSA advisory

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7636,19 +7636,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/mermaid/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -10875,9 +10862,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/website/package.json
+++ b/website/package.json
@@ -18,6 +18,9 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },
+  "overrides": {
+    "uuid": "^14.0.0"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/react": "^18.3.12",


### PR DESCRIPTION
## Summary

Closes the failing Dependabot job ([run 24852946262](https://github.com/anand-92/droidproxy/actions/runs/24852946262)) and clears Dependabot security alert #7 (moderate, `uuid` in `/website`).

## Problem

Dependabot reported:

```
security_update_not_possible
  dependency-name: uuid
  latest-resolvable-version: 11.1.0
  lowest-non-vulnerable-version: 14.0.0
  explanation: No patched version available for uuid
```

Two transitive copies of `uuid` were installed:
- `node_modules/uuid@13.0.0` via `@lobehub/ui` (peer: `uuid@^13.0.0`)
- `node_modules/mermaid/node_modules/uuid@11.1.0` via `mermaid` (peer: `uuid@^11.1.0`)

The advisory requires `uuid >= 14.0.0`. Neither upstream has published a release that accepts `uuid@14` yet, so Dependabot can't resolve it on its own.

## Fix

Add an npm `overrides` block to `website/package.json` forcing `uuid@^14` across the whole tree:

```json
"overrides": {
  "uuid": "^14.0.0"
}
```

After regenerating the lockfile, only one copy remains:

```
node_modules/uuid => 14.0.0
```

(mermaid's nested copy dedupes away onto v14.)

## Verification

```
cd website
npm install --legacy-peer-deps   # existing vite peer conflict, unrelated
npm run build                    # ✓ built in 860ms, 11747 modules transformed
```

No `11.1.0` references remain in the built bundle. Bundle size unchanged (278.41 kB / 79.06 kB gzipped).

## Risk

`uuid` 11 → 14 is mostly internal refactoring; the public API (`v4`, `v5`, `validate`, etc.) is unchanged. If `mermaid` / `@lobehub/ui` happen to import a removed internal, the override can be reverted and the alert dismissed instead.