### PR TITLE
feat: add advanced Factory model entries

### DIFF
--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -17,7 +17,9 @@ enum AppPreferences {
     static let allowRemoteKey = "allowRemote"
     static let secretKeyKey = "secretKey"
     static let oledThemeKey = "oledTheme"
+    static let factoryAdvancedModelsKey = "factoryAdvancedModels"
     static let defaultOledTheme = false
+    static let defaultFactoryAdvancedModels = false
     static let defaultOpus47ThinkingEffort = "xhigh"
     static let defaultOpus46ThinkingEffort = "max"
     static let defaultOpus45ThinkingEffort = "high"

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+enum DroidProxyModelKind {
+    case claudeAdaptive
+    case claudeClassic
+    case codex
+    case gemini
+}
+
+struct DroidProxyThinkingLevel: Equatable {
+    let value: String
+    let displayName: String
+}
+
+struct DroidProxyModelDefinition: Equatable {
+    let baseModel: String
+    let idSlug: String
+    let displayName: String
+    let maxOutputTokens: Int
+    let provider: String
+    let providerKey: String
+    let baseURL: String
+    let kind: DroidProxyModelKind
+    let levelLabel: String
+    let levels: [DroidProxyThinkingLevel]
+
+    var simpleID: String {
+        "custom:droidproxy:\(idSlug)"
+    }
+
+    func advancedID(for level: DroidProxyThinkingLevel) -> String {
+        "custom:droidproxy:\(idSlug)-\(level.value)"
+    }
+
+    func modelAlias(for level: DroidProxyThinkingLevel) -> String {
+        "\(baseModel)(\(level.value))"
+    }
+
+    var simpleSettingsEntry: [String: Any] {
+        settingsEntry(id: simpleID, model: baseModel, displayName: "DroidProxy: \(displayName)")
+    }
+
+    func advancedSettingsEntry(for level: DroidProxyThinkingLevel) -> [String: Any] {
+        settingsEntry(
+            id: advancedID(for: level),
+            model: modelAlias(for: level),
+            displayName: "DroidProxy: \(displayName) - \(level.displayName) \(levelLabel)"
+        )
+    }
+
+    private func settingsEntry(id: String, model: String, displayName: String) -> [String: Any] {
+        [
+            "model": model,
+            "id": id,
+            "baseUrl": baseURL,
+            "apiKey": "dummy-not-used",
+            "displayName": displayName,
+            "maxOutputTokens": maxOutputTokens,
+            "noImageSupport": false,
+            "provider": provider
+        ]
+    }
+}
+
+struct DroidProxyModelVariant {
+    let definition: DroidProxyModelDefinition
+    let level: DroidProxyThinkingLevel
+}
+
+enum DroidProxyModelCatalog {
+    private static let minimal = DroidProxyThinkingLevel(value: "minimal", displayName: "Minimal")
+    private static let low = DroidProxyThinkingLevel(value: "low", displayName: "Low")
+    private static let medium = DroidProxyThinkingLevel(value: "medium", displayName: "Medium")
+    private static let high = DroidProxyThinkingLevel(value: "high", displayName: "High")
+    private static let xhigh = DroidProxyThinkingLevel(value: "xhigh", displayName: "xHigh")
+    private static let max = DroidProxyThinkingLevel(value: "max", displayName: "Max")
+
+    private static let claudeAdvancedLevels = [low, medium, high, xhigh, max]
+    private static let claudeClassicLevels = [low, medium, high, max]
+    private static let codexLevels = [low, medium, high, xhigh]
+    private static let geminiProLevels = [low, medium, high]
+    private static let geminiFlashLevels = [minimal, low, medium, high]
+
+    static let definitions: [DroidProxyModelDefinition] = [
+        DroidProxyModelDefinition(
+            baseModel: "claude-opus-4-7",
+            idSlug: "opus-4-7",
+            displayName: "Opus 4.7",
+            maxOutputTokens: 128000,
+            provider: "anthropic",
+            providerKey: "claude",
+            baseURL: "http://localhost:8317",
+            kind: .claudeAdaptive,
+            levelLabel: "Thinking",
+            levels: claudeAdvancedLevels
+        ),
+        DroidProxyModelDefinition(
+            baseModel: "claude-opus-4-6",
+            idSlug: "opus-4-6",
+            displayName: "Opus 4.6",
+            maxOutputTokens: 128000,
+            provider: "anthropic",
+            providerKey: "claude",
+            baseURL: "http://localhost:8317",
+            kind: .claudeAdaptive,
+            levelLabel: "Thinking",
+            levels: claudeClassicLevels
+        ),
+        DroidProxyModelDefinition(
+            baseModel: "claude-opus-4-5-20251101",
+            idSlug: "opus-4-5",
+            displayName: "Opus 4.5",
+            maxOutputTokens: 64000,
+            provider: "anthropic",
+            providerKey: "claude",
+            baseURL: "http://localhost:8317",
+            kind: .claudeClassic,
+            levelLabel: "Thinking",
+            levels: claudeClassicLevels
+        ),
+        DroidProxyModelDefinition(
+            baseModel: "claude-sonnet-4-6",
+            idSlug: "sonnet-4-6",
+            displayName: "Sonnet 4.6",
+            maxOutputTokens: 64000,
+            provider: "anthropic",
+            providerKey: "claude",
+            baseURL: "http://localhost:8317",
+            kind: .claudeAdaptive,
+            levelLabel: "Thinking",
+            levels: claudeClassicLevels
+        ),
+        DroidProxyModelDefinition(
+            baseModel: "gpt-5.3-codex",
+            idSlug: "gpt-5.3-codex",
+            displayName: "GPT 5.3 Codex",
+            maxOutputTokens: 128000,
+            provider: "openai",
+            providerKey: "codex",
+            baseURL: "http://localhost:8317/v1",
+            kind: .codex,
+            levelLabel: "Reasoning",
+            levels: codexLevels
+        ),
+        DroidProxyModelDefinition(
+            baseModel: "gpt-5.4",
+            idSlug: "gpt-5.4",
+            displayName: "GPT 5.4",
+            maxOutputTokens: 128000,
+            provider: "openai",
+            providerKey: "codex",
+            baseURL: "http://localhost:8317/v1",
+            kind: .codex,
+            levelLabel: "Reasoning",
+            levels: codexLevels
+        ),
+        DroidProxyModelDefinition(
+            baseModel: "gpt-5.5",
+            idSlug: "gpt-5.5",
+            displayName: "GPT 5.5",
+            maxOutputTokens: 128000,
+            provider: "openai",
+            providerKey: "codex",
+            baseURL: "http://localhost:8317/v1",
+            kind: .codex,
+            levelLabel: "Reasoning",
+            levels: codexLevels
+        ),
+        DroidProxyModelDefinition(
+            baseModel: "gemini-3.1-pro-preview",
+            idSlug: "gemini-3.1-pro",
+            displayName: "Gemini 3.1 Pro",
+            maxOutputTokens: 65536,
+            provider: "google",
+            providerKey: "gemini",
+            baseURL: "http://localhost:8317",
+            kind: .gemini,
+            levelLabel: "Thinking",
+            levels: geminiProLevels
+        ),
+        DroidProxyModelDefinition(
+            baseModel: "gemini-3-flash-preview",
+            idSlug: "gemini-3-flash",
+            displayName: "Gemini 3 Flash",
+            maxOutputTokens: 65536,
+            provider: "google",
+            providerKey: "gemini",
+            baseURL: "http://localhost:8317",
+            kind: .gemini,
+            levelLabel: "Thinking",
+            levels: geminiFlashLevels
+        )
+    ]
+
+    static func settingsModels(advanced: Bool) -> [[String: Any]] {
+        if advanced {
+            return definitions.flatMap { definition in
+                definition.levels.map { definition.advancedSettingsEntry(for: $0) }
+            }
+        }
+        return definitions.map(\.simpleSettingsEntry)
+    }
+
+    static var allSettingsIDs: Set<String> {
+        Set(definitions.flatMap { definition in
+            [definition.simpleID] + definition.levels.map { definition.advancedID(for: $0) }
+        })
+    }
+
+    static func providerKey(forSettingsModel model: [String: Any]) -> String? {
+        if let id = model["id"] as? String,
+           let definition = definitions.first(where: { definition in
+               id == definition.simpleID || definition.levels.contains { definition.advancedID(for: $0) == id }
+           }) {
+            return definition.providerKey
+        }
+
+        guard let name = model["model"] as? String else { return nil }
+        if name.hasPrefix("claude") { return "claude" }
+        if name.hasPrefix("gpt") { return "codex" }
+        if name.hasPrefix("gemini") { return "gemini" }
+        return nil
+    }
+
+    static func advancedVariant(for model: String) -> DroidProxyModelVariant? {
+        guard model.hasSuffix(")"),
+              let openIndex = model.lastIndex(of: "(") else {
+            return nil
+        }
+
+        let base = String(model[..<openIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let levelStart = model.index(after: openIndex)
+        let levelEnd = model.index(before: model.endIndex)
+        let requestedLevel = String(model[levelStart..<levelEnd])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        guard !base.isEmpty, !requestedLevel.isEmpty else { return nil }
+
+        for definition in definitions where definition.baseModel == base {
+            if let level = definition.levels.first(where: { $0.value == requestedLevel }) {
+                return DroidProxyModelVariant(definition: definition, level: level)
+            }
+        }
+
+        return nil
+    }
+}

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -91,7 +91,7 @@ enum DroidProxyModelCatalog {
             providerKey: "claude",
             baseURL: "http://localhost:8317",
             kind: .claudeAdaptive,
-            levelLabel: "Thinking",
+            levelLabel: "Effort",
             levels: claudeAdvancedLevels
         ),
         DroidProxyModelDefinition(
@@ -103,7 +103,7 @@ enum DroidProxyModelCatalog {
             providerKey: "claude",
             baseURL: "http://localhost:8317",
             kind: .claudeAdaptive,
-            levelLabel: "Thinking",
+            levelLabel: "Effort",
             levels: claudeClassicLevels
         ),
         DroidProxyModelDefinition(
@@ -115,7 +115,7 @@ enum DroidProxyModelCatalog {
             providerKey: "claude",
             baseURL: "http://localhost:8317",
             kind: .claudeClassic,
-            levelLabel: "Thinking",
+            levelLabel: "Effort",
             levels: claudeClassicLevels
         ),
         DroidProxyModelDefinition(
@@ -127,7 +127,7 @@ enum DroidProxyModelCatalog {
             providerKey: "claude",
             baseURL: "http://localhost:8317",
             kind: .claudeAdaptive,
-            levelLabel: "Thinking",
+            levelLabel: "Effort",
             levels: claudeClassicLevels
         ),
         DroidProxyModelDefinition(

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -926,6 +926,21 @@ struct SettingsView: View {
                             if codexModelsExpanded {
                                 if factoryAdvancedModels {
                                     advancedFactoryModelsNotice("Codex")
+                                    codexFastModeToggleRow(
+                                        "GPT 5.3 Codex",
+                                        isOn: $gpt53CodexFastMode,
+                                        helpText: "Injects service_tier=priority for GPT 5.3 Codex Responses API requests (Codex fast mode)"
+                                    )
+                                    codexFastModeToggleRow(
+                                        "GPT 5.4",
+                                        isOn: $gpt54FastMode,
+                                        helpText: "Injects service_tier=priority for GPT 5.4 Responses API requests (Codex fast mode)"
+                                    )
+                                    codexFastModeToggleRow(
+                                        "GPT 5.5",
+                                        isOn: $gpt55FastMode,
+                                        helpText: "Injects service_tier=priority for GPT 5.5 Responses API requests (Codex fast mode)"
+                                    )
                                 } else {
                                     VStack(alignment: .leading, spacing: 6) {
                                         HStack {
@@ -1188,6 +1203,21 @@ struct SettingsView: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func codexFastModeToggleRow(_ title: String, isOn: Binding<Bool>, helpText: String) -> some View {
+        HStack {
+            Text("\(title) fast mode")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Spacer()
+            Toggle("Fast mode", isOn: isOn)
+                .toggleStyle(.checkbox)
+                .font(.caption)
+                .help(helpText)
+        }
+        .padding(.vertical, 2)
     }
 
     @ViewBuilder

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -522,6 +522,7 @@ struct SettingsView: View {
     @AppStorage(AppPreferences.secretKeyKey) private var secretKey = AppPreferences.defaultSecretKey
     @AppStorage(AppPreferences.claudeMaxBudgetModeKey) private var claudeMaxBudgetMode = AppPreferences.defaultClaudeMaxBudgetMode
     @AppStorage(AppPreferences.oledThemeKey) private var oledTheme = AppPreferences.defaultOledTheme
+    @AppStorage(AppPreferences.factoryAdvancedModelsKey) private var factoryAdvancedModels = AppPreferences.defaultFactoryAdvancedModels
     @State private var authenticatingService: ServiceType? = nil
     @State private var showingAuthResult = false
     @State private var authResultMessage = ""
@@ -674,25 +675,42 @@ struct SettingsView: View {
                         .controlSize(.small)
                     }
 
-                    HStack {
-                        Text("Factory custom models")
-                        Spacer()
-                        if factoryModelsInstalled {
-                            HStack(spacing: 4) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundColor(.green)
-                                    .font(.caption)
-                                Text("Applied")
-                                    .font(.caption)
-                                    .foregroundColor(.green)
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text("Factory custom models")
+                            Spacer()
+                            if factoryModelsInstalled {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundColor(.green)
+                                        .font(.caption)
+                                    Text("Applied")
+                                        .font(.caption)
+                                        .foregroundColor(.green)
+                                }
                             }
+                            Button(factoryModelsInstalled ? "Re-apply" : "Apply") {
+                                applyFactoryCustomModels()
+                            }
+                            .droidGlassProminent()
+                            .controlSize(.small)
                         }
-                        Button(factoryModelsInstalled ? "Re-apply" : "Apply") {
-                            applyFactoryCustomModels()
+
+                        Toggle("Advanced: add one Factory model entry per reasoning/thinking level", isOn: $factoryAdvancedModels)
+                            .toggleStyle(.checkbox)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .onChange(of: factoryAdvancedModels) { _ in
+                                factoryModelsInstalled = checkFactoryModelsInstalled()
+                                challengerPluginInstalled = checkChallengerPluginInstalled()
+                            }
+
+                        Text(factoryAdvancedModels
+                             ? "Apply writes separate Low/Medium/High/etc. model aliases into ~/.factory/settings.json."
+                             : "Apply writes the default DroidProxy model aliases into ~/.factory/settings.json.")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
                         }
-                        .droidGlassProminent()
-                        .controlSize(.small)
-                    }
 
                     HStack {
                         Text("Challenger Plugin")
@@ -821,48 +839,52 @@ struct SettingsView: View {
                                 }
                             }
                             if claudeModelsExpanded {
-                                MaxBudgetToggleView(isOn: $claudeMaxBudgetMode)
-                                    .onChange(of: claudeMaxBudgetMode) { enabled in
-                                        if enabled {
-                                            showingMaxBudgetWarning = true
-                                            opus46ThinkingEffort = "max"
-                                            sonnet46ThinkingEffort = "max"
+                                if factoryAdvancedModels {
+                                    advancedFactoryModelsNotice("Claude")
+                                } else {
+                                    MaxBudgetToggleView(isOn: $claudeMaxBudgetMode)
+                                        .onChange(of: claudeMaxBudgetMode) { enabled in
+                                            if enabled {
+                                                showingMaxBudgetWarning = true
+                                                opus46ThinkingEffort = "max"
+                                                sonnet46ThinkingEffort = "max"
+                                            }
                                         }
-                                    }
-                                collapsibleEffortPickerRow(
-                                    "Opus 4.7 thinking effort",
-                                    selection: $opus47ThinkingEffort,
-                                    options: ["low", "medium", "high", "xhigh", "max"],
-                                    tint: claudeEffortSelectionColor,
-                                    isExpanded: $opus47EffortExpanded
-                                )
-                                collapsibleEffortPickerRow(
-                                    "Opus 4.6 thinking effort",
-                                    selection: $opus46ThinkingEffort,
-                                    options: ["low", "medium", "high", "max"],
-                                    tint: claudeEffortSelectionColor,
-                                    isExpanded: $opus46EffortExpanded,
-                                    overrideBadge: claudeMaxBudgetMode ? "MAX MODE" : nil
-                                )
-                                .disabled(claudeMaxBudgetMode)
-                                .opacity(claudeMaxBudgetMode ? 0.45 : 1.0)
-                                collapsibleEffortPickerRow(
-                                    "Opus 4.5 thinking effort",
-                                    selection: $opus45ThinkingEffort,
-                                    options: ["low", "medium", "high", "max"],
-                                    tint: claudeEffortSelectionColor,
-                                    isExpanded: $opus45EffortExpanded
-                                )
-                                collapsibleEffortPickerRow(
-                                    "Sonnet 4.6 thinking effort",
-                                    selection: $sonnet46ThinkingEffort,
-                                    options: ["low", "medium", "high", "max"],
-                                    tint: claudeEffortSelectionColor,
-                                    isExpanded: $sonnet46EffortExpanded,
-                                    overrideBadge: claudeMaxBudgetMode ? "MAX MODE" : nil
-                                )
-                                .disabled(claudeMaxBudgetMode)
-                                .opacity(claudeMaxBudgetMode ? 0.45 : 1.0)
+                                    collapsibleEffortPickerRow(
+                                        "Opus 4.7 thinking effort",
+                                        selection: $opus47ThinkingEffort,
+                                        options: ["low", "medium", "high", "xhigh", "max"],
+                                        tint: claudeEffortSelectionColor,
+                                        isExpanded: $opus47EffortExpanded
+                                    )
+                                    collapsibleEffortPickerRow(
+                                        "Opus 4.6 thinking effort",
+                                        selection: $opus46ThinkingEffort,
+                                        options: ["low", "medium", "high", "max"],
+                                        tint: claudeEffortSelectionColor,
+                                        isExpanded: $opus46EffortExpanded,
+                                        overrideBadge: claudeMaxBudgetMode ? "MAX MODE" : nil
+                                    )
+                                    .disabled(claudeMaxBudgetMode)
+                                    .opacity(claudeMaxBudgetMode ? 0.45 : 1.0)
+                                    collapsibleEffortPickerRow(
+                                        "Opus 4.5 thinking effort",
+                                        selection: $opus45ThinkingEffort,
+                                        options: ["low", "medium", "high", "max"],
+                                        tint: claudeEffortSelectionColor,
+                                        isExpanded: $opus45EffortExpanded
+                                    )
+                                    collapsibleEffortPickerRow(
+                                        "Sonnet 4.6 thinking effort",
+                                        selection: $sonnet46ThinkingEffort,
+                                        options: ["low", "medium", "high", "max"],
+                                        tint: claudeEffortSelectionColor,
+                                        isExpanded: $sonnet46EffortExpanded,
+                                        overrideBadge: claudeMaxBudgetMode ? "MAX MODE" : nil
+                                    )
+                                    .disabled(claudeMaxBudgetMode)
+                                    .opacity(claudeMaxBudgetMode ? 0.45 : 1.0)
+                                }
                             }
                         }
                         .padding(.leading, 28)
@@ -902,69 +924,73 @@ struct SettingsView: View {
                                 }
                             }
                             if codexModelsExpanded {
-                                VStack(alignment: .leading, spacing: 6) {
-                                    HStack {
-                                        Text("GPT 5.3 Codex reasoning effort")
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                        Spacer()
-                                        Toggle("Fast mode", isOn: $gpt53CodexFastMode)
-                                            .toggleStyle(.checkbox)
-                                            .font(.caption)
-                                            .help("Injects service_tier=priority for GPT 5.3 Codex Responses API requests (Codex fast mode)")
-                                    }
-                                    Picker("", selection: $gpt53CodexReasoningEffort) {
-                                        ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
-                                            Text(option).tag(option)
+                                if factoryAdvancedModels {
+                                    advancedFactoryModelsNotice("Codex")
+                                } else {
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        HStack {
+                                            Text("GPT 5.3 Codex reasoning effort")
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+                                            Spacer()
+                                            Toggle("Fast mode", isOn: $gpt53CodexFastMode)
+                                                .toggleStyle(.checkbox)
+                                                .font(.caption)
+                                                .help("Injects service_tier=priority for GPT 5.3 Codex Responses API requests (Codex fast mode)")
                                         }
-                                    }
-                                    .pickerStyle(.segmented)
-                                    .tint(codexEffortSelectionColor)
-                                    .labelsHidden()
-                                }
-                                .padding(.vertical, 2)
-                                VStack(alignment: .leading, spacing: 6) {
-                                    HStack {
-                                        Text("GPT 5.4 reasoning effort")
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                        Spacer()
-                                        Toggle("Fast mode", isOn: $gpt54FastMode)
-                                            .toggleStyle(.checkbox)
-                                            .font(.caption)
-                                            .help("Injects service_tier=priority for GPT 5.4 Responses API requests (Codex fast mode)")
-                                    }
-                                    Picker("", selection: $gpt54ReasoningEffort) {
-                                        ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
-                                            Text(option).tag(option)
+                                        Picker("", selection: $gpt53CodexReasoningEffort) {
+                                            ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
+                                                Text(option).tag(option)
+                                            }
                                         }
+                                        .pickerStyle(.segmented)
+                                        .tint(codexEffortSelectionColor)
+                                        .labelsHidden()
                                     }
-                                    .pickerStyle(.segmented)
-                                    .tint(codexEffortSelectionColor)
-                                    .labelsHidden()
-                                }
-                                .padding(.vertical, 2)
-                                VStack(alignment: .leading, spacing: 6) {
-                                    HStack {
-                                        Text("GPT 5.5 reasoning effort")
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                        Spacer()
-                                        Toggle("Fast mode", isOn: $gpt55FastMode)
-                                            .toggleStyle(.checkbox)
-                                            .font(.caption)
-                                            .help("Injects service_tier=priority for GPT 5.5 Responses API requests (Codex fast mode)")
-                                    }
-                                    Picker("", selection: $gpt55ReasoningEffort) {
-                                        ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
-                                            Text(option).tag(option)
+                                    .padding(.vertical, 2)
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        HStack {
+                                            Text("GPT 5.4 reasoning effort")
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+                                            Spacer()
+                                            Toggle("Fast mode", isOn: $gpt54FastMode)
+                                                .toggleStyle(.checkbox)
+                                                .font(.caption)
+                                                .help("Injects service_tier=priority for GPT 5.4 Responses API requests (Codex fast mode)")
                                         }
+                                        Picker("", selection: $gpt54ReasoningEffort) {
+                                            ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
+                                                Text(option).tag(option)
+                                            }
+                                        }
+                                        .pickerStyle(.segmented)
+                                        .tint(codexEffortSelectionColor)
+                                        .labelsHidden()
                                     }
-                                    .pickerStyle(.segmented)
-                                    .tint(codexEffortSelectionColor)
-                                    .labelsHidden()
+                                    .padding(.vertical, 2)
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        HStack {
+                                            Text("GPT 5.5 reasoning effort")
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+                                            Spacer()
+                                            Toggle("Fast mode", isOn: $gpt55FastMode)
+                                                .toggleStyle(.checkbox)
+                                                .font(.caption)
+                                                .help("Injects service_tier=priority for GPT 5.5 Responses API requests (Codex fast mode)")
+                                        }
+                                        Picker("", selection: $gpt55ReasoningEffort) {
+                                            ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
+                                                Text(option).tag(option)
+                                            }
+                                        }
+                                        .pickerStyle(.segmented)
+                                        .tint(codexEffortSelectionColor)
+                                        .labelsHidden()
+                                    }
+                                    .padding(.vertical, 2)
                                 }
-                                .padding(.vertical, 2)
                             }
                         }
                         .padding(.leading, 28)
@@ -1004,18 +1030,22 @@ struct SettingsView: View {
                                 }
                             }
                             if geminiModelsExpanded {
-                                effortPickerRow(
-                                    "Gemini 3.1 Pro thinking level",
-                                    selection: $gemini31ProThinkingLevel,
-                                    options: ["low", "medium", "high"],
-                                    tint: geminiEffortSelectionColor
-                                )
-                                effortPickerRow(
-                                    "Gemini 3 Flash thinking level",
-                                    selection: $gemini3FlashThinkingLevel,
-                                    options: ["minimal", "low", "medium", "high"],
-                                    tint: geminiEffortSelectionColor
-                                )
+                                if factoryAdvancedModels {
+                                    advancedFactoryModelsNotice("Gemini")
+                                } else {
+                                    effortPickerRow(
+                                        "Gemini 3.1 Pro thinking level",
+                                        selection: $gemini31ProThinkingLevel,
+                                        options: ["low", "medium", "high"],
+                                        tint: geminiEffortSelectionColor
+                                    )
+                                    effortPickerRow(
+                                        "Gemini 3 Flash thinking level",
+                                        selection: $gemini3FlashThinkingLevel,
+                                        options: ["minimal", "low", "medium", "high"],
+                                        tint: geminiEffortSelectionColor
+                                    )
+                                }
                             }
                         }
                         .padding(.leading, 28)
@@ -1145,6 +1175,20 @@ struct SettingsView: View {
     }
 
     // MARK: - Actions
+
+    @ViewBuilder
+    private func advancedFactoryModelsNotice(_ providerName: String) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "slider.horizontal.3")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Text("Advanced Factory models are on. Re-apply custom models to pick \(providerName) reasoning/thinking levels directly from Factory's model picker.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 4)
+    }
 
     @ViewBuilder
     private func effortPickerRow(_ title: String, selection: Binding<String>, options: [String], tint: Color = AccountRowView.accent, overrideBadge: String? = nil) -> some View {
@@ -1361,111 +1405,10 @@ struct SettingsView: View {
     /// so users don't end up with stale entries next to the current ones.
     private static let legacyDroidProxyModelIds: Set<String> = []
 
-    private static let droidProxyModels: [[String: Any]] = [
-        [
-            "model": "claude-opus-4-7",
-            "id": "custom:droidproxy:opus-4-7",
-            "baseUrl": "http://localhost:8317",
-            "apiKey": "dummy-not-used",
-            "displayName": "DroidProxy: Opus 4.7",
-            "maxOutputTokens": 128000,
-            "noImageSupport": false,
-            "provider": "anthropic"
-        ],
-        [
-            "model": "claude-opus-4-6",
-            "id": "custom:droidproxy:opus-4-6",
-            "baseUrl": "http://localhost:8317",
-            "apiKey": "dummy-not-used",
-            "displayName": "DroidProxy: Opus 4.6",
-            "maxOutputTokens": 128000,
-            "noImageSupport": false,
-            "provider": "anthropic"
-        ],
-        [
-            "model": "claude-opus-4-5-20251101",
-            "id": "custom:droidproxy:opus-4-5",
-            "baseUrl": "http://localhost:8317",
-            "apiKey": "dummy-not-used",
-            "displayName": "DroidProxy: Opus 4.5",
-            "maxOutputTokens": 64000,
-            "noImageSupport": false,
-            "provider": "anthropic"
-        ],
-        [
-            "model": "claude-sonnet-4-6",
-            "id": "custom:droidproxy:sonnet-4-6",
-            "baseUrl": "http://localhost:8317",
-            "apiKey": "dummy-not-used",
-            "displayName": "DroidProxy: Sonnet 4.6",
-            "maxOutputTokens": 64000,
-            "noImageSupport": false,
-            "provider": "anthropic"
-        ],
-        [
-            "model": "gpt-5.3-codex",
-            "id": "custom:droidproxy:gpt-5.3-codex",
-            "baseUrl": "http://localhost:8317/v1",
-            "apiKey": "dummy-not-used",
-            "displayName": "DroidProxy: GPT 5.3 Codex",
-            "maxOutputTokens": 128000,
-            "noImageSupport": false,
-            "provider": "openai"
-        ],
-        [
-            "model": "gpt-5.4",
-            "id": "custom:droidproxy:gpt-5.4",
-            "baseUrl": "http://localhost:8317/v1",
-            "apiKey": "dummy-not-used",
-            "displayName": "DroidProxy: GPT 5.4",
-            "maxOutputTokens": 128000,
-            "noImageSupport": false,
-            "provider": "openai"
-        ],
-        [
-            "model": "gpt-5.5",
-            "id": "custom:droidproxy:gpt-5.5",
-            "baseUrl": "http://localhost:8317/v1",
-            "apiKey": "dummy-not-used",
-            "displayName": "DroidProxy: GPT 5.5",
-            "maxOutputTokens": 128000,
-            "noImageSupport": false,
-            "provider": "openai"
-        ],
-        [
-            "model": "gemini-3.1-pro-preview",
-            "id": "custom:droidproxy:gemini-3.1-pro",
-            "baseUrl": "http://localhost:8317",
-            "apiKey": "dummy-not-used",
-            "displayName": "DroidProxy: Gemini 3.1 Pro",
-            "maxOutputTokens": 65536,
-            "noImageSupport": false,
-            "provider": "google"
-        ],
-        [
-            "model": "gemini-3-flash-preview",
-            "id": "custom:droidproxy:gemini-3-flash",
-            "baseUrl": "http://localhost:8317",
-            "apiKey": "dummy-not-used",
-            "displayName": "DroidProxy: Gemini 3 Flash",
-            "maxOutputTokens": 65536,
-            "noImageSupport": false,
-            "provider": "google"
-        ]
-    ]
-
     private func factorySettingsURL() -> URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".factory")
             .appendingPathComponent("settings.json")
-    }
-
-    private func providerKey(for model: [String: Any]) -> String? {
-        guard let name = model["model"] as? String else { return nil }
-        if name.hasPrefix("claude") { return "claude" }
-        if name.hasPrefix("gpt") { return "codex" }
-        if name.hasPrefix("gemini") { return "gemini" }
-        return nil
     }
 
     private func checkFactoryModelsInstalled() -> Bool {
@@ -1475,13 +1418,18 @@ struct SettingsView: View {
               let models = json["customModels"] as? [[String: Any]] else {
             return false
         }
-        let existingIds = Set(models.compactMap { $0["id"] as? String })
-        let enabledModels = Self.droidProxyModels.filter { model in
-            guard let key = providerKey(for: model) else { return true }
+        let enabledModels = DroidProxyModelCatalog.settingsModels(advanced: factoryAdvancedModels).filter { model in
+            guard let key = DroidProxyModelCatalog.providerKey(forSettingsModel: model) else { return true }
             return serverManager.isProviderEnabled(key)
         }
-        let droidIds = Set(enabledModels.compactMap { $0["id"] as? String })
-        return !droidIds.isEmpty && droidIds.isSubset(of: existingIds)
+        let expectedIds = Set(enabledModels.compactMap { $0["id"] as? String })
+        let installedDroidProxyIds = Set(models.compactMap { $0["id"] as? String }.filter { id in
+            DroidProxyModelCatalog.allSettingsIDs.contains(id)
+                || Self.legacyDroidProxyModelIds.contains(id)
+                || id.hasPrefix("custom:droidproxy:")
+                || id.hasPrefix("custom:CC:")
+        })
+        return !expectedIds.isEmpty && installedDroidProxyIds == expectedIds
     }
 
     private func applyFactoryCustomModels() {
@@ -1498,14 +1446,16 @@ struct SettingsView: View {
 
         var models = (settings["customModels"] as? [[String: Any]]) ?? []
 
-        let droidIds = Set(Self.droidProxyModels.compactMap { $0["id"] as? String })
         models.removeAll { item in
             guard let id = item["id"] as? String else { return false }
-            return droidIds.contains(id) || Self.legacyDroidProxyModelIds.contains(id) || id.hasPrefix("custom:CC:")
+            return DroidProxyModelCatalog.allSettingsIDs.contains(id)
+                || Self.legacyDroidProxyModelIds.contains(id)
+                || id.hasPrefix("custom:droidproxy:")
+                || id.hasPrefix("custom:CC:")
         }
 
-        let enabledModels = Self.droidProxyModels.filter { model in
-            guard let key = providerKey(for: model) else { return true }
+        let enabledModels = DroidProxyModelCatalog.settingsModels(advanced: factoryAdvancedModels).filter { model in
+            guard let key = DroidProxyModelCatalog.providerKey(forSettingsModel: model) else { return true }
             return serverManager.isProviderEnabled(key)
         }
         let startIndex = models.count
@@ -1525,7 +1475,8 @@ struct SettingsView: View {
             try data.write(to: url, options: .atomic)
             factoryModelsInstalled = true
             authResultSuccess = true
-            authResultMessage = "DroidProxy models added to Factory settings.\n\nRestart Factory (or open a new session) to see them in the model picker."
+            let mode = factoryAdvancedModels ? "Advanced DroidProxy model entries" : "DroidProxy models"
+            authResultMessage = "\(mode) added to Factory settings.\n\nRestart Factory (or open a new session) to see them in the model picker."
             showingAuthResult = true
             NSLog("[SettingsView] Factory custom models applied to %@", url.path)
         } catch {
@@ -1698,8 +1649,30 @@ struct SettingsView: View {
         let home = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".factory")
         return Self.challengerPluginFiles.allSatisfy { entry in
             let url = home.appendingPathComponent(entry.directory).appendingPathComponent(entry.filename)
-            return FileManager.default.fileExists(atPath: url.path)
+            guard let existing = try? String(contentsOf: url, encoding: .utf8) else {
+                return false
+            }
+            return existing == renderedChallengerPluginContent(entry.content)
         }
+    }
+
+    private func renderedChallengerPluginContent(_ content: String) -> String {
+        var rendered = content
+        if factoryAdvancedModels {
+            rendered = rendered
+                .replacingOccurrences(of: "model: custom:droidproxy:opus-4-7", with: "model: custom:droidproxy:opus-4-7-xhigh")
+                .replacingOccurrences(of: "model: custom:droidproxy:gpt-5.5", with: "model: custom:droidproxy:gpt-5.5-high")
+                .replacingOccurrences(of: "model: custom:droidproxy:gemini-3.1-pro", with: "model: custom:droidproxy:gemini-3.1-pro-high")
+        }
+
+        return rendered
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line in
+                var s = String(line)
+                while s.hasPrefix("        ") { s = String(s.dropFirst(8)) }
+                return s
+            }
+            .joined(separator: "\n")
     }
 
     private func applyChallengerPlugin() {
@@ -1711,16 +1684,7 @@ struct SettingsView: View {
                 let dir = home.appendingPathComponent(entry.directory)
                 try fm.createDirectory(at: dir, withIntermediateDirectories: true)
                 let fileURL = dir.appendingPathComponent(entry.filename)
-                // Trim leading whitespace from each line caused by Swift multi-line string indentation
-                let trimmed = entry.content
-                    .split(separator: "\n", omittingEmptySubsequences: false)
-                    .map { line in
-                        var s = String(line)
-                        while s.hasPrefix("        ") { s = String(s.dropFirst(8)) }
-                        return s
-                    }
-                    .joined(separator: "\n")
-                try trimmed.write(to: fileURL, atomically: true, encoding: .utf8)
+                try renderedChallengerPluginContent(entry.content).write(to: fileURL, atomically: true, encoding: .utf8)
             }
             challengerPluginInstalled = true
             authResultSuccess = true

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -329,8 +329,7 @@ class ThinkingProxy {
 
         if let level = geminiThinkingLevel(for: model) {
             var result = jsonString
-            result = injectJSONField(in: result, afterKey: "model", fieldName: "generationConfig",
-                                     fieldValue: "{\"thinkingConfig\":{\"thinking_level\":\"\(level)\"}}")
+            result = injectGeminiThinkingLevel(in: result, level: level, generationConfigExists: json["generationConfig"] != nil)
             NSLog("[ThinkingProxy] Injected Gemini thinking for '\(model)' with level '\(level)'")
             ThinkingProxy.fileLog("INJECTED Gemini thinking: level=\(level) for model \(model)")
             return result
@@ -365,8 +364,7 @@ class ThinkingProxy {
 
         case .gemini:
             var result = rewrittenJSON
-            result = injectJSONField(in: result, afterKey: "model", fieldName: "generationConfig",
-                                     fieldValue: "{\"thinkingConfig\":{\"thinking_level\":\"\(level)\"}}")
+            result = injectGeminiThinkingLevel(in: result, level: level, generationConfigExists: json["generationConfig"] != nil)
             NSLog("[ThinkingProxy] Injected advanced Gemini thinking for '\(requestedModel)' as '\(baseModel)' with level '\(level)'")
             ThinkingProxy.fileLog("INJECTED advanced Gemini thinking: level=\(level) for model \(requestedModel) -> \(baseModel)")
             return result
@@ -437,6 +435,64 @@ class ThinkingProxy {
             return replaceJSONFieldValue(in: json, fieldName: fieldName, newValue: fieldValue)
         }
         return injectJSONField(in: json, afterKey: afterKey, fieldName: fieldName, fieldValue: fieldValue)
+    }
+
+    private func injectGeminiThinkingLevel(in json: String, level: String, generationConfigExists: Bool) -> String {
+        let generationConfigValue = "{\"thinkingConfig\":{\"thinking_level\":\"\(level)\"}}"
+        guard generationConfigExists else {
+            return injectJSONField(in: json, afterKey: "model", fieldName: "generationConfig", fieldValue: generationConfigValue)
+        }
+
+        guard let generationConfigLocation = findTopLevelFieldLocation(in: json, key: "generationConfig") else {
+            NSLog("[ThinkingProxy] Warning: Could not find generationConfig for Gemini thinking merge")
+            return json
+        }
+
+        let generationConfig = String(json[generationConfigLocation.valueRange])
+        guard let updatedGenerationConfig = upsertGeminiThinkingLevel(inGenerationConfig: generationConfig, level: level) else {
+            return replaceJSONFieldValue(in: json, fieldName: "generationConfig", newValue: generationConfigValue)
+        }
+
+        var result = json
+        result.replaceSubrange(generationConfigLocation.valueRange, with: updatedGenerationConfig)
+        return result
+    }
+
+    private func upsertGeminiThinkingLevel(inGenerationConfig generationConfig: String, level: String) -> String? {
+        let thinkingConfigValue = "{\"thinking_level\":\"\(level)\"}"
+        guard let thinkingConfigLocation = findTopLevelFieldLocation(in: generationConfig, key: "thinkingConfig") else {
+            return upsertJSONField(inObject: generationConfig, fieldName: "thinkingConfig", fieldValue: thinkingConfigValue)
+        }
+
+        let thinkingConfig = String(generationConfig[thinkingConfigLocation.valueRange])
+        let updatedThinkingConfig = upsertJSONField(inObject: thinkingConfig,
+                                                    fieldName: "thinking_level",
+                                                    fieldValue: "\"\(level)\"") ?? thinkingConfigValue
+
+        var result = generationConfig
+        result.replaceSubrange(thinkingConfigLocation.valueRange, with: updatedThinkingConfig)
+        return result
+    }
+
+    private func upsertJSONField(inObject object: String, fieldName: String, fieldValue: String) -> String? {
+        guard let objectStart = firstNonWhitespaceIndex(in: object, from: object.startIndex),
+              object[objectStart] == "{",
+              let objectEnd = lastNonWhitespaceIndex(in: object),
+              object[objectEnd] == "}" else {
+            return nil
+        }
+
+        if let location = findTopLevelFieldLocation(in: object, key: fieldName) {
+            var result = object
+            result.replaceSubrange(location.valueRange, with: fieldValue)
+            return result
+        }
+
+        var result = object
+        let contentStart = object.index(after: objectStart)
+        let isEmptyObject = firstNonWhitespaceIndex(in: object, from: contentStart) == objectEnd
+        result.insert(contentsOf: "\(isEmptyObject ? "" : ",")\"\(fieldName)\":\(fieldValue)", at: objectEnd)
+        return result
     }
 
     /// Replaces the value of an existing top-level JSON field.
@@ -652,6 +708,17 @@ class ThinkingProxy {
             index = json.index(after: index)
         }
         return index < json.endIndex ? index : nil
+    }
+
+    private func lastNonWhitespaceIndex(in json: String) -> String.Index? {
+        var index = json.endIndex
+        while index > json.startIndex {
+            index = json.index(before: index)
+            if !json[index].isWhitespace {
+                return index
+            }
+        }
+        return nil
     }
 
     private func parseJSONStringToken(in json: String, startingAt startQuote: String.Index) -> (String, String.Index)? {

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -314,6 +314,10 @@ class ThinkingProxy {
             return nil
         }
 
+        if let variant = DroidProxyModelCatalog.advancedVariant(for: model) {
+            return processAdvancedModelVariant(jsonString: jsonString, json: json, requestedModel: model, variant: variant)
+        }
+
         if let effort = codexReasoningEffort(for: model) {
             var result = jsonString
             result = injectJSONField(in: result, afterKey: "model", fieldName: "reasoning",
@@ -341,12 +345,47 @@ class ThinkingProxy {
             return nil
         }
 
+        return processClaudeAdaptiveThinking(jsonString: jsonString, json: json, model: model, effort: effort, allowMaxBudgetMode: true)
+    }
+
+    private func processAdvancedModelVariant(jsonString: String, json: [String: Any], requestedModel: String, variant: DroidProxyModelVariant) -> String? {
+        let baseModel = variant.definition.baseModel
+        let level = variant.level.value
+        let rewrittenJSON = rewriteModelValue(in: jsonString, from: requestedModel, to: baseModel)
+
+        switch variant.definition.kind {
+        case .codex:
+            var result = rewrittenJSON
+            result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "reasoning",
+                                              fieldValue: "{\"effort\":\"\(level)\"}",
+                                              existsInJSON: json["reasoning"] != nil)
+            NSLog("[ThinkingProxy] Injected advanced Codex reasoning for '\(requestedModel)' as '\(baseModel)' with effort '\(level)'")
+            ThinkingProxy.fileLog("INJECTED advanced Codex reasoning: effort=\(level) for model \(requestedModel) -> \(baseModel)")
+            return result
+
+        case .gemini:
+            var result = rewrittenJSON
+            result = injectJSONField(in: result, afterKey: "model", fieldName: "generationConfig",
+                                     fieldValue: "{\"thinkingConfig\":{\"thinking_level\":\"\(level)\"}}")
+            NSLog("[ThinkingProxy] Injected advanced Gemini thinking for '\(requestedModel)' as '\(baseModel)' with level '\(level)'")
+            ThinkingProxy.fileLog("INJECTED advanced Gemini thinking: level=\(level) for model \(requestedModel) -> \(baseModel)")
+            return result
+
+        case .claudeClassic:
+            return processOpus45ClassicThinking(jsonString: rewrittenJSON, json: json, model: baseModel, effort: level)
+
+        case .claudeAdaptive:
+            return processClaudeAdaptiveThinking(jsonString: rewrittenJSON, json: json, model: baseModel, effort: level, allowMaxBudgetMode: false)
+        }
+    }
+
+    private func processClaudeAdaptiveThinking(jsonString: String, json: [String: Any], model: String, effort: String, allowMaxBudgetMode: Bool) -> String {
         var result = jsonString
 
         result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "stream",
                                           fieldValue: "true", existsInJSON: json["stream"] != nil)
 
-        if AppPreferences.claudeMaxBudgetMode &&
+        if allowMaxBudgetMode && AppPreferences.claudeMaxBudgetMode &&
             (model.contains("sonnet-4-6") || model.contains("opus-4-6")) {
             // Sonnet 4.6 / Opus 4.6 classic extended-thinking override. budget_tokens must be strictly less
             // than max_tokens (min 1024). Request body changes stay inside the adaptive-thinking
@@ -446,8 +485,7 @@ class ThinkingProxy {
     /// Opus 4.5 does not accept adaptive thinking. It requires the legacy
     /// `thinking: {type: "enabled", budget_tokens: N}` shape, where
     /// `budget_tokens < max_tokens` (min 1024).
-    private func processOpus45ClassicThinking(jsonString: String, json: [String: Any], model: String) -> String? {
-        let effort = AppPreferences.opus45ThinkingEffort
+    private func processOpus45ClassicThinking(jsonString: String, json: [String: Any], model: String, effort: String = AppPreferences.opus45ThinkingEffort) -> String? {
         let (budgetTokens, maxTokens) = opus45ClassicBudget(for: effort)
 
         var result = jsonString


### PR DESCRIPTION
## Summary

- Added an Advanced Factory custom-model mode that writes a separate custom model for each supported Claude effort, Codex reasoning, and Gemini thinking level.
- Centralized DroidProxy model metadata so Settings and ThinkingProxy share aliases, IDs, display names, and supported levels.
- Updated ThinkingProxy to unwrap advanced aliases like `gpt-5.5(xhigh)` to their base model while injecting the selected level.
- Preserved existing Gemini `generationConfig` fields while merging injected thinking levels to avoid duplicate JSON keys.
- Kept GPT Fast Mode toggles visible in advanced mode so each base GPT model can still opt into `service_tier=priority`.
- Kept Challenger Plugin generated model references aligned with the selected Factory model mode.

## Testing

- `swift build --package-path /Users/dks0662779/droidproxy/src`
- `git diff --check`

## Fixes

- Fixes #54
