### PR TITLE
Fix Codex auth cooldown blackouts and Responses API session stickiness (#57, #58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+- **Codex `auth_unavailable` blackout during long sessions** ([#57](https://github.com/anand-92/droidproxy/issues/57)) -- Bundled `config.yaml` now sets `disable-cooling: true` so a single transient failure on a Codex/Claude/Gemini auth no longer parks every available account behind a cooldown window. Long Factory/Droid sessions on `gpt-5.5`, `gpt-5.4`, etc. no longer fail with `503 auth_unavailable: no auth available (providers=codex,github-copilot)` after working normally for hours.
+- **Encrypted reasoning state mismatch on `/v1/responses`** ([#58](https://github.com/anand-92/droidproxy/issues/58)) -- Bundled `config.yaml` now enables `routing.session-affinity: true` (TTL `2h`). Stateful Codex Responses API turns now stay pinned to the same upstream auth, so encrypted reasoning content created on turn N is no longer replayed through a different account on turn N+1 with `400 The encrypted content ... could not be verified`.
+
 ### Changed
 - **Claude Opus 4.7 migration** -- Opus 4.6 support replaced with Opus 4.7 throughout the app: model detection (`claude-opus-4-7`), Settings UI label, Factory custom models entry (`custom:droidproxy:opus-4-7`), and the bundled Challenger droid (`challenger-opus`) now target Opus 4.7. Effort options are `low` / `medium` / `high` / `xhigh` / `max`, with a default of `xhigh` per Anthropic's recommendation for coding and agentic workloads.
 - **Opus 4.6 Factory custom model** -- `custom:droidproxy:opus-4-6` is removed from `customModels` during Apply/Re-apply so users don't end up with stale entries alongside the new Opus 4.7 model.

--- a/src/Sources/Resources/config.yaml
+++ b/src/Sources/Resources/config.yaml
@@ -34,6 +34,22 @@ request-retry: 3
 # Important for Extended Thinking requests which may take 5-10+ minutes.
 request-timeout: "10m"
 
+# Disable global auth/model cooldown scheduling.
+# Prevents long Factory/Droid sessions from hitting blackout windows where every
+# Codex/Claude/Gemini auth shows as "auth_unavailable" after a single transient
+# failure. See https://github.com/anand-92/droidproxy/issues/57.
+disable-cooling: true
+
+# Routing strategy
+routing:
+  strategy: "round-robin"
+  # Pin a session to one upstream auth so stateful Responses API traffic
+  # (encrypted reasoning state, previous_response_id) does not break when a
+  # follow-up turn would otherwise round-robin to a different account.
+  # See https://github.com/anand-92/droidproxy/issues/58.
+  session-affinity: true
+  session-affinity-ttl: "2h"
+
 # Quota management
 quota-exceeded:
   switch-project: true


### PR DESCRIPTION
## Summary

Two reliability fixes for long Factory/Droid sessions through DroidProxy, both implemented as small additions to the bundled `config.yaml` for `cli-proxy-api-plus`. Closes #57 and #58.

The bundled `cli-proxy-api-plus` binary (`v6.9.28-0-plus`) already supports both options — they were just not being set in the config DroidProxy ships. Verified by inspecting the YAML struct tags in the binary (`disable-cooling`, `session-affinity`, `session-affinity-ttl`, `claude-code-session-affinity`) and by booting the backend with the new config locally.

I also looked at the `KooshaPari/cliproxyapi-plusplus` fork — every release there ships source-only (0 release assets) and trails the upstream binary in features, so swapping the bundled binary is not a meaningful upgrade for these two issues.

## Changes

`src/Sources/Resources/config.yaml`:

```yaml
# Disable global auth/model cooldown scheduling.
disable-cooling: true

# Routing strategy
routing:
  strategy: "round-robin"
  session-affinity: true
  session-affinity-ttl: "2h"
```

`CHANGELOG.md`: documented both fixes under `Unreleased`.

## Why this fixes #57 (`503 auth_unavailable`)

Reporter's investigation in #57 already pinpointed cooldown scheduling as the root cause: after one transient failure, every eligible Codex/GitHub-Copilot auth got parked behind a cooldown window, and the user-facing error `503 auth_unavailable: no auth available (providers=codex,github-copilot, model=gpt-5.5)` looked like a Factory custom-model misconfiguration. Setting `disable-cooling: true` matches the workaround the reporter validated locally.

## Why this fixes #58 (encrypted reasoning state)

The Responses API returns encrypted reasoning state that is only decryptable by the same upstream account that created it. With pure round-robin selection, turn N+1 of a session can land on a different account, which then rejects the replayed encrypted blob with `400 The encrypted content ... could not be verified`. Enabling `routing.session-affinity` makes the bundled backend pin a session to one auth (it already extracts session IDs from `X-Session-ID`, `Session_id`, `previous_response_id`-style state, etc.), and automatic failover still kicks in if the bound auth becomes unavailable. The 2h TTL covers typical long Factory missions without keeping bindings around forever.

## Testing

- `swift build` from `src/` — clean build, no new warnings introduced.
- Started `cli-proxy-api-plus` against the new config — backend parses both new keys, registers all auths, and reaches `API server started successfully on: 127.0.0.1:8318` before the test process is killed (the only subsequent error is "address already in use" because DroidProxy was already running on the same port in this dev environment, which confirms the YAML parsed cleanly).

## Closes

- Closes #57
- Closes #58