### PR TITLE
feat: add Claude and Codex usage probes to menu bar

### DIFF
--- a/src/Sources/AppDelegate.swift
+++ b/src/Sources/AppDelegate.swift
@@ -431,16 +431,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
         menu.item(withTag: 202)?.isHidden = !showUsage
         menu.item(withTag: 203)?.isHidden = !showUsage
         
-        guard showUsage else {
-            // Restore original title if usage hidden
-            if statusItem.button?.title != "" {
-                statusItem.button?.title = ""
-            }
-            return
+        if statusItem.button?.title != "" {
+            statusItem.button?.title = ""
         }
-        
-        var titleComponents = [String]()
-        
+
+        guard showUsage else { return }
+
         if let claudeItem = menu.item(withTag: 200) {
             if let snapshot = UsageStore.shared.claudeUsage {
                 if let error = snapshot.error {
@@ -450,19 +446,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
                 } else {
                     let hourly = snapshot.windows.first { $0.kind == .other } // We mapped 5h to other
                     let weekly = snapshot.windows.first { $0.kind == .weekly }
-                    
+
                     var title = "● Claude"
                     if let h = hourly {
                         title += String(format: "   5h: %2d%%", Int(h.percentUsed))
-                        titleComponents.append(String(format: "Cl %d", Int(h.percentUsed)))
                     }
                     if let w = weekly {
                         title += String(format: "   Week: %2d%%", Int(w.percentUsed))
-                        if titleComponents.isEmpty {
-                            titleComponents.append(String(format: "Cl %d/%d", Int(hourly?.percentUsed ?? 0), Int(w.percentUsed)))
-                        } else {
-                            titleComponents[titleComponents.count - 1] += String(format: "/%d", Int(w.percentUsed))
-                        }
                     }
                     if let h = hourly, let resetsAt = h.resetsAt {
                         let diff = Int(resetsAt.timeIntervalSinceNow / 3600)
@@ -474,7 +464,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
                 claudeItem.title = "● Claude   Loading..."
             }
         }
-        
+
         if let codexItem = menu.item(withTag: 201) {
             if let snapshot = UsageStore.shared.codexUsage {
                 if let error = snapshot.error {
@@ -484,19 +474,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
                 } else {
                     let hourly = snapshot.windows.first { $0.kind == .other }
                     let weekly = snapshot.windows.first { $0.kind == .weekly }
-                    
+
                     var title = "● Codex"
                     if let h = hourly {
                         title += String(format: "    5h: %2d%%", Int(h.percentUsed))
-                        titleComponents.append(String(format: "Cx %d", Int(h.percentUsed)))
                     }
                     if let w = weekly {
                         title += String(format: "   Week: %2d%%", Int(w.percentUsed))
-                        if titleComponents.isEmpty {
-                            // Shouldn't hit but just in case
-                        } else {
-                            titleComponents[titleComponents.count - 1] += String(format: "/%d", Int(w.percentUsed))
-                        }
                     }
                     if let h = hourly, let resetsAt = h.resetsAt {
                         let diff = Int(resetsAt.timeIntervalSinceNow / 3600)
@@ -507,12 +491,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
             } else {
                 codexItem.title = "● Codex    Loading..."
             }
-        }
-        
-        let newTitle = titleComponents.joined(separator: "  ")
-        if statusItem.button?.title != newTitle {
-            statusItem.button?.title = newTitle
-            statusItem.button?.imagePosition = .imageLeft
         }
     }
 

--- a/src/Sources/AppDelegate.swift
+++ b/src/Sources/AppDelegate.swift
@@ -33,6 +33,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
         // Initialize managers
         serverManager = ServerManager()
         thinkingProxy = ThinkingProxy()
+        
+        // Initialize UsageStore
+        UsageStore.shared.start()
 
         // Warm commonly used icons to avoid first-use disk hits
         preloadIcons()
@@ -47,6 +50,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
             self,
             selector: #selector(updateMenuBarStatus),
             name: .serverStatusChanged,
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateUsageMenu),
+            name: .usageUpdated,
+            object: nil
+        )
+        
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(handleWake),
+            name: NSWorkspace.didWakeNotification,
             object: nil
         )
 
@@ -145,6 +162,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
         // Main Actions
         menu.addItem(NSMenuItem(title: "Open Settings", action: #selector(openSettings), keyEquivalent: "s"))
         menu.addItem(NSMenuItem.separator())
+        
+        // Usage
+        let claudeUsageItem = NSMenuItem(title: "● Claude   --", action: nil, keyEquivalent: "")
+        claudeUsageItem.tag = 200
+        menu.addItem(claudeUsageItem)
+        
+        let codexUsageItem = NSMenuItem(title: "● Codex    --", action: nil, keyEquivalent: "")
+        codexUsageItem.tag = 201
+        menu.addItem(codexUsageItem)
+        
+        let refreshUsageItem = NSMenuItem(title: "Refresh Usage", action: #selector(refreshUsage), keyEquivalent: "r")
+        refreshUsageItem.tag = 202
+        menu.addItem(refreshUsageItem)
+        
+        let usageSeparator = NSMenuItem.separator()
+        usageSeparator.tag = 203
+        menu.addItem(usageSeparator)
 
         // Server Control
         let startStopItem = NSMenuItem(title: "Start Server", action: #selector(toggleServer), keyEquivalent: "")
@@ -378,6 +412,107 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
             if let error = error {
                 NSLog("[Notifications] Failed to deliver notification '%@': %@", title, error.localizedDescription)
             }
+        }
+    }
+
+    @MainActor @objc func refreshUsage() {
+        UsageStore.shared.refresh()
+    }
+    
+    @MainActor @objc func handleWake() {
+        UsageStore.shared.refresh()
+    }
+    
+    @MainActor @objc func updateUsageMenu() {
+        let showUsage = AppPreferences.showUsageInMenuBar
+        
+        menu.item(withTag: 200)?.isHidden = !showUsage
+        menu.item(withTag: 201)?.isHidden = !showUsage
+        menu.item(withTag: 202)?.isHidden = !showUsage
+        menu.item(withTag: 203)?.isHidden = !showUsage
+        
+        guard showUsage else {
+            // Restore original title if usage hidden
+            if statusItem.button?.title != "" {
+                statusItem.button?.title = ""
+            }
+            return
+        }
+        
+        var titleComponents = [String]()
+        
+        if let claudeItem = menu.item(withTag: 200) {
+            if let snapshot = UsageStore.shared.claudeUsage {
+                if let error = snapshot.error {
+                    claudeItem.title = "● Claude   Error: \(error)"
+                } else if snapshot.windows.isEmpty {
+                    claudeItem.title = "● Claude   No usage data"
+                } else {
+                    let hourly = snapshot.windows.first { $0.kind == .other } // We mapped 5h to other
+                    let weekly = snapshot.windows.first { $0.kind == .weekly }
+                    
+                    var title = "● Claude"
+                    if let h = hourly {
+                        title += String(format: "   5h: %2d%%", Int(h.percentUsed))
+                        titleComponents.append(String(format: "Cl %d", Int(h.percentUsed)))
+                    }
+                    if let w = weekly {
+                        title += String(format: "   Week: %2d%%", Int(w.percentUsed))
+                        if titleComponents.isEmpty {
+                            titleComponents.append(String(format: "Cl %d/%d", Int(hourly?.percentUsed ?? 0), Int(w.percentUsed)))
+                        } else {
+                            titleComponents[titleComponents.count - 1] += String(format: "/%d", Int(w.percentUsed))
+                        }
+                    }
+                    if let h = hourly, let resetsAt = h.resetsAt {
+                        let diff = Int(resetsAt.timeIntervalSinceNow / 3600)
+                        title += "   (resets \(diff)h)"
+                    }
+                    claudeItem.title = title
+                }
+            } else {
+                claudeItem.title = "● Claude   Loading..."
+            }
+        }
+        
+        if let codexItem = menu.item(withTag: 201) {
+            if let snapshot = UsageStore.shared.codexUsage {
+                if let error = snapshot.error {
+                    codexItem.title = "● Codex    Error: \(error)"
+                } else if snapshot.windows.isEmpty {
+                    codexItem.title = "● Codex    No usage data"
+                } else {
+                    let hourly = snapshot.windows.first { $0.kind == .other }
+                    let weekly = snapshot.windows.first { $0.kind == .weekly }
+                    
+                    var title = "● Codex"
+                    if let h = hourly {
+                        title += String(format: "    5h: %2d%%", Int(h.percentUsed))
+                        titleComponents.append(String(format: "Cx %d", Int(h.percentUsed)))
+                    }
+                    if let w = weekly {
+                        title += String(format: "   Week: %2d%%", Int(w.percentUsed))
+                        if titleComponents.isEmpty {
+                            // Shouldn't hit but just in case
+                        } else {
+                            titleComponents[titleComponents.count - 1] += String(format: "/%d", Int(w.percentUsed))
+                        }
+                    }
+                    if let h = hourly, let resetsAt = h.resetsAt {
+                        let diff = Int(resetsAt.timeIntervalSinceNow / 3600)
+                        title += "   (resets \(diff)h)"
+                    }
+                    codexItem.title = title
+                }
+            } else {
+                codexItem.title = "● Codex    Loading..."
+            }
+        }
+        
+        let newTitle = titleComponents.joined(separator: "  ")
+        if statusItem.button?.title != newTitle {
+            statusItem.button?.title = newTitle
+            statusItem.button?.imagePosition = .imageLeft
         }
     }
 

--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -35,6 +35,22 @@ enum AppPreferences {
     static let defaultClaudeMaxBudgetMode = false
     static let defaultAllowRemote = false
     static let defaultSecretKey = ""
+    static let showUsageInMenuBarKey = "showUsageInMenuBar"
+    static let usageAutoRefreshSecondsKey = "usageAutoRefreshSeconds"
+    static let defaultShowUsageInMenuBar = true
+    static let defaultUsageAutoRefreshSeconds = 300
+
+    static var showUsageInMenuBar: Bool {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: showUsageInMenuBarKey) != nil else { return defaultShowUsageInMenuBar }
+        return defaults.bool(forKey: showUsageInMenuBarKey)
+    }
+
+    static var usageAutoRefreshSeconds: Int {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: usageAutoRefreshSecondsKey) != nil else { return defaultUsageAutoRefreshSeconds }
+        return defaults.integer(forKey: usageAutoRefreshSecondsKey)
+    }
 
     static var opus47ThinkingEffort: String {
         let defaults = UserDefaults.standard

--- a/src/Sources/ClaudeUsageProbe.swift
+++ b/src/Sources/ClaudeUsageProbe.swift
@@ -9,7 +9,7 @@ class ClaudeUsageProbe {
         let expired: String?
     }
 
-    private static let expirationFormatters: [ISO8601DateFormatter] = {
+    private static let dateFormatters: [ISO8601DateFormatter] = {
         let withFractional = ISO8601DateFormatter()
         withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let plain = ISO8601DateFormatter()
@@ -17,9 +17,9 @@ class ClaudeUsageProbe {
         return [withFractional, plain]
     }()
 
-    private static func parseExpiration(_ value: String?) -> Date? {
+    private static func parseDate(_ value: String?) -> Date? {
         guard let value else { return nil }
-        for formatter in expirationFormatters {
+        for formatter in dateFormatters {
             if let date = formatter.date(from: value) { return date }
         }
         return nil
@@ -31,7 +31,7 @@ class ClaudeUsageProbe {
             let data = try Data(contentsOf: fileURL)
             var tokenInfo = try JSONDecoder().decode(TokenInfo.self, from: data)
 
-            if let expiresAt = Self.parseExpiration(tokenInfo.expired), expiresAt <= Date() {
+            if let expiresAt = Self.parseDate(tokenInfo.expired), expiresAt <= Date() {
                 tokenInfo = try await refreshTokens(fileURL: fileURL, currentTokenInfo: tokenInfo)
             }
 
@@ -43,11 +43,10 @@ class ClaudeUsageProbe {
     
     private func findClaudeAuthFile() throws -> URL {
         let contents = try FileManager.default.contentsOfDirectory(at: authDir, includingPropertiesForKeys: nil)
-        for url in contents {
-            if url.lastPathComponent.hasPrefix("claude-") && url.lastPathComponent.hasSuffix(".json") {
-                return url
-            }
-        }
+        let matches = contents
+            .filter { $0.lastPathComponent.hasPrefix("claude-") && $0.lastPathComponent.hasSuffix(".json") }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        if let first = matches.first { return first }
         throw NSError(domain: "ClaudeUsageProbe", code: 1, userInfo: [NSLocalizedDescriptionKey: "No claude auth file found"])
     }
     
@@ -61,7 +60,8 @@ class ClaudeUsageProbe {
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         
-        let body = "client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&grant_type=refresh_token&refresh_token=\(refreshToken)"
+        let encodedToken = refreshToken.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let body = "client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&grant_type=refresh_token&refresh_token=\(encodedToken)"
         request.httpBody = body.data(using: .utf8)
         
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -86,7 +86,7 @@ class ClaudeUsageProbe {
         existingJson["last_refresh"] = isoFormatter.string(from: Date())
 
         let newData = try JSONSerialization.data(withJSONObject: existingJson, options: [.prettyPrinted])
-        try newData.write(to: fileURL)
+        try newData.write(to: fileURL, options: [.atomic])
 
         return TokenInfo(access_token: newAccess, refresh_token: newRefresh, expired: newExpiresAt)
     }
@@ -137,16 +137,6 @@ class ClaudeUsageProbe {
         let decoder = JSONDecoder()
         let raw = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] ?? [:]
 
-        let withFractional = ISO8601DateFormatter()
-        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let plain = ISO8601DateFormatter()
-        plain.formatOptions = [.withInternetDateTime]
-
-        func parseDate(_ str: String?) -> Date? {
-            guard let str else { return nil }
-            return withFractional.date(from: str) ?? plain.date(from: str)
-        }
-
         let knownBuckets: [(key: String, kind: UsageWindowKind)] = [
             ("five_hour", .other),
             ("seven_day", .weekly),
@@ -165,10 +155,10 @@ class ClaudeUsageProbe {
             guard let utilization = bucket.utilization else { continue }
             windows.append(UsageWindow(
                 kind: kind,
-                limit: 100,
-                used: Int(utilization.rounded()),
+                limit: 0,
+                used: 0,
                 percentUsed: utilization,
-                resetsAt: parseDate(bucket.resets_at)
+                resetsAt: Self.parseDate(bucket.resets_at)
             ))
         }
 

--- a/src/Sources/ClaudeUsageProbe.swift
+++ b/src/Sources/ClaudeUsageProbe.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+class ClaudeUsageProbe {
+    private let authDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cli-proxy-api")
+    
+    struct TokenInfo: Codable {
+        let access_token: String
+        let refresh_token: String?
+        let expired: Bool?
+    }
+    
+    func fetchUsage() async -> ProviderUsageSnapshot {
+        do {
+            let fileURL = try findClaudeAuthFile()
+            let data = try Data(contentsOf: fileURL)
+            var tokenInfo = try JSONDecoder().decode(TokenInfo.self, from: data)
+            
+            if tokenInfo.expired == true {
+                tokenInfo = try await refreshTokens(fileURL: fileURL, currentTokenInfo: tokenInfo)
+            }
+            
+            return try await executeUsageRequest(token: tokenInfo.access_token, fileURL: fileURL, tokenInfo: tokenInfo)
+        } catch {
+            return ProviderUsageSnapshot(provider: "Claude", lastUpdated: Date(), windows: [], error: error.localizedDescription)
+        }
+    }
+    
+    private func findClaudeAuthFile() throws -> URL {
+        let contents = try FileManager.default.contentsOfDirectory(at: authDir, includingPropertiesForKeys: nil)
+        for url in contents {
+            if url.lastPathComponent.hasPrefix("claude-") && url.lastPathComponent.hasSuffix(".json") {
+                return url
+            }
+        }
+        throw NSError(domain: "ClaudeUsageProbe", code: 1, userInfo: [NSLocalizedDescriptionKey: "No claude auth file found"])
+    }
+    
+    private func refreshTokens(fileURL: URL, currentTokenInfo: TokenInfo) async throws -> TokenInfo {
+        guard let refreshToken = currentTokenInfo.refresh_token else {
+            throw NSError(domain: "ClaudeUsageProbe", code: 2, userInfo: [NSLocalizedDescriptionKey: "No refresh token available"])
+        }
+        
+        NSLog("ClaudeUsageProbe: Refreshing tokens")
+        var request = URLRequest(url: URL(string: "https://platform.claude.com/v1/oauth/token")!)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        
+        let body = "client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&grant_type=refresh_token&refresh_token=\(refreshToken)"
+        request.httpBody = body.data(using: .utf8)
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw NSError(domain: "ClaudeUsageProbe", code: 3, userInfo: [NSLocalizedDescriptionKey: "Token refresh failed"])
+        }
+        
+        let newTokens = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] ?? [:]
+        guard let newAccess = newTokens["access_token"] as? String, let newRefresh = newTokens["refresh_token"] as? String else {
+            throw NSError(domain: "ClaudeUsageProbe", code: 4, userInfo: [NSLocalizedDescriptionKey: "Invalid token response format"])
+        }
+        
+        // Read existing JSON to preserve structure, just update fields
+        var existingJson = try JSONSerialization.jsonObject(with: try Data(contentsOf: fileURL), options: []) as? [String: Any] ?? [:]
+        existingJson["access_token"] = newAccess
+        existingJson["refresh_token"] = newRefresh
+        existingJson["expired"] = false
+        
+        let newData = try JSONSerialization.data(withJSONObject: existingJson, options: [.prettyPrinted])
+        try newData.write(to: fileURL)
+        
+        return TokenInfo(access_token: newAccess, refresh_token: newRefresh, expired: false)
+    }
+    
+    private func executeUsageRequest(token: String, fileURL: URL, tokenInfo: TokenInfo) async throws -> ProviderUsageSnapshot {
+        var request = URLRequest(url: URL(string: "https://api.anthropic.com/api/oauth/usage")!)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NSError(domain: "ClaudeUsageProbe", code: 5, userInfo: [NSLocalizedDescriptionKey: "Invalid response"])
+        }
+        
+        if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+            NSLog("ClaudeUsageProbe: Token rejected (401/403), attempting refresh")
+            let newTokens = try await refreshTokens(fileURL: fileURL, currentTokenInfo: tokenInfo)
+            
+            var retryRequest = URLRequest(url: URL(string: "https://api.anthropic.com/api/oauth/usage")!)
+            retryRequest.setValue("Bearer \(newTokens.access_token)", forHTTPHeaderField: "Authorization")
+            retryRequest.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+            
+            let (retryData, retryResponse) = try await URLSession.shared.data(for: retryRequest)
+            guard let retryHttpResponse = retryResponse as? HTTPURLResponse, retryHttpResponse.statusCode == 200 else {
+                throw NSError(domain: "ClaudeUsageProbe", code: 6, userInfo: [NSLocalizedDescriptionKey: "Usage fetch failed after refresh"])
+            }
+            return try parseUsage(data: retryData)
+        }
+        
+        guard httpResponse.statusCode == 200 else {
+            throw NSError(domain: "ClaudeUsageProbe", code: 7, userInfo: [NSLocalizedDescriptionKey: "HTTP Error \(httpResponse.statusCode)"])
+        }
+        
+        return try parseUsage(data: data)
+    }
+    
+    private func parseUsage(data: Data) throws -> ProviderUsageSnapshot {
+        // Expected Anthropic structure:
+        // { "rate_limits": [ { "window": "5h", "limit": 1000, "used": 120, "resets_at": "2026-05-07T..." }, { "window": "weekly", ... } ] }
+        struct AnthropicUsage: Codable {
+            struct Limit: Codable {
+                let window: String
+                let limit: Int
+                let used: Int
+                let resets_at: String?
+            }
+            let rate_limits: [Limit]
+        }
+        
+        let apiResponse = try JSONDecoder().decode(AnthropicUsage.self, from: data)
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let fallbackFormatter = ISO8601DateFormatter()
+        
+        let windows: [UsageWindow] = apiResponse.rate_limits.map { limit in
+            let kind: UsageWindowKind
+            if limit.window == "5h" { kind = .other } // Map 5h to other for now, handled by UI
+            else if limit.window.lowercased().contains("week") { kind = .weekly }
+            else if limit.window.lowercased().contains("hour") { kind = .hourly }
+            else { kind = .other }
+            
+            let percent = limit.limit > 0 ? (Double(limit.used) / Double(limit.limit)) * 100.0 : 0.0
+            
+            var resetsAt: Date? = nil
+            if let resetsStr = limit.resets_at {
+                resetsAt = dateFormatter.date(from: resetsStr) ?? fallbackFormatter.date(from: resetsStr)
+            }
+            
+            return UsageWindow(kind: kind, limit: limit.limit, used: limit.used, percentUsed: percent, resetsAt: resetsAt)
+        }
+        
+        return ProviderUsageSnapshot(provider: "Claude", lastUpdated: Date(), windows: windows, error: nil)
+    }
+}

--- a/src/Sources/ClaudeUsageProbe.swift
+++ b/src/Sources/ClaudeUsageProbe.swift
@@ -6,19 +6,35 @@ class ClaudeUsageProbe {
     struct TokenInfo: Codable {
         let access_token: String
         let refresh_token: String?
-        let expired: Bool?
+        let expired: String?
     }
-    
+
+    private static let expirationFormatters: [ISO8601DateFormatter] = {
+        let withFractional = ISO8601DateFormatter()
+        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        return [withFractional, plain]
+    }()
+
+    private static func parseExpiration(_ value: String?) -> Date? {
+        guard let value else { return nil }
+        for formatter in expirationFormatters {
+            if let date = formatter.date(from: value) { return date }
+        }
+        return nil
+    }
+
     func fetchUsage() async -> ProviderUsageSnapshot {
         do {
             let fileURL = try findClaudeAuthFile()
             let data = try Data(contentsOf: fileURL)
             var tokenInfo = try JSONDecoder().decode(TokenInfo.self, from: data)
-            
-            if tokenInfo.expired == true {
+
+            if let expiresAt = Self.parseExpiration(tokenInfo.expired), expiresAt <= Date() {
                 tokenInfo = try await refreshTokens(fileURL: fileURL, currentTokenInfo: tokenInfo)
             }
-            
+
             return try await executeUsageRequest(token: tokenInfo.access_token, fileURL: fileURL, tokenInfo: tokenInfo)
         } catch {
             return ProviderUsageSnapshot(provider: "Claude", lastUpdated: Date(), windows: [], error: error.localizedDescription)
@@ -57,17 +73,22 @@ class ClaudeUsageProbe {
         guard let newAccess = newTokens["access_token"] as? String, let newRefresh = newTokens["refresh_token"] as? String else {
             throw NSError(domain: "ClaudeUsageProbe", code: 4, userInfo: [NSLocalizedDescriptionKey: "Invalid token response format"])
         }
-        
-        // Read existing JSON to preserve structure, just update fields
+
+        let expiresIn = (newTokens["expires_in"] as? Double) ?? 3600
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime]
+        let newExpiresAt = isoFormatter.string(from: Date().addingTimeInterval(expiresIn))
+
         var existingJson = try JSONSerialization.jsonObject(with: try Data(contentsOf: fileURL), options: []) as? [String: Any] ?? [:]
         existingJson["access_token"] = newAccess
         existingJson["refresh_token"] = newRefresh
-        existingJson["expired"] = false
-        
+        existingJson["expired"] = newExpiresAt
+        existingJson["last_refresh"] = isoFormatter.string(from: Date())
+
         let newData = try JSONSerialization.data(withJSONObject: existingJson, options: [.prettyPrinted])
         try newData.write(to: fileURL)
-        
-        return TokenInfo(access_token: newAccess, refresh_token: newRefresh, expired: false)
+
+        return TokenInfo(access_token: newAccess, refresh_token: newRefresh, expired: newExpiresAt)
     }
     
     private func executeUsageRequest(token: String, fileURL: URL, tokenInfo: TokenInfo) async throws -> ProviderUsageSnapshot {
@@ -103,40 +124,54 @@ class ClaudeUsageProbe {
     }
     
     private func parseUsage(data: Data) throws -> ProviderUsageSnapshot {
-        // Expected Anthropic structure:
-        // { "rate_limits": [ { "window": "5h", "limit": 1000, "used": 120, "resets_at": "2026-05-07T..." }, { "window": "weekly", ... } ] }
-        struct AnthropicUsage: Codable {
-            struct Limit: Codable {
-                let window: String
-                let limit: Int
-                let used: Int
-                let resets_at: String?
-            }
-            let rate_limits: [Limit]
+        // Actual Anthropic response (oauth/usage):
+        // { "five_hour": {"utilization": 30.0, "resets_at": "..."},
+        //   "seven_day": null, "seven_day_opus": null, "seven_day_sonnet": null,
+        //   "seven_day_oauth_apps": null, "seven_day_omelette": {"utilization": 0.0, "resets_at": null},
+        //   "extra_usage": {...} }
+        struct Bucket: Decodable {
+            let utilization: Double?
+            let resets_at: String?
         }
-        
-        let apiResponse = try JSONDecoder().decode(AnthropicUsage.self, from: data)
-        let dateFormatter = ISO8601DateFormatter()
-        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let fallbackFormatter = ISO8601DateFormatter()
-        
-        let windows: [UsageWindow] = apiResponse.rate_limits.map { limit in
-            let kind: UsageWindowKind
-            if limit.window == "5h" { kind = .other } // Map 5h to other for now, handled by UI
-            else if limit.window.lowercased().contains("week") { kind = .weekly }
-            else if limit.window.lowercased().contains("hour") { kind = .hourly }
-            else { kind = .other }
-            
-            let percent = limit.limit > 0 ? (Double(limit.used) / Double(limit.limit)) * 100.0 : 0.0
-            
-            var resetsAt: Date? = nil
-            if let resetsStr = limit.resets_at {
-                resetsAt = dateFormatter.date(from: resetsStr) ?? fallbackFormatter.date(from: resetsStr)
-            }
-            
-            return UsageWindow(kind: kind, limit: limit.limit, used: limit.used, percentUsed: percent, resetsAt: resetsAt)
+
+        let decoder = JSONDecoder()
+        let raw = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] ?? [:]
+
+        let withFractional = ISO8601DateFormatter()
+        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+
+        func parseDate(_ str: String?) -> Date? {
+            guard let str else { return nil }
+            return withFractional.date(from: str) ?? plain.date(from: str)
         }
-        
+
+        let knownBuckets: [(key: String, kind: UsageWindowKind)] = [
+            ("five_hour", .other),
+            ("seven_day", .weekly),
+            ("seven_day_opus", .weekly),
+            ("seven_day_sonnet", .weekly),
+            ("seven_day_oauth_apps", .weekly),
+            ("seven_day_cowork", .weekly),
+            ("seven_day_omelette", .weekly)
+        ]
+
+        var windows: [UsageWindow] = []
+        for (key, kind) in knownBuckets {
+            guard let dict = raw[key] as? [String: Any] else { continue }
+            let bucketData = try JSONSerialization.data(withJSONObject: dict, options: [])
+            let bucket = try decoder.decode(Bucket.self, from: bucketData)
+            guard let utilization = bucket.utilization else { continue }
+            windows.append(UsageWindow(
+                kind: kind,
+                limit: 100,
+                used: Int(utilization.rounded()),
+                percentUsed: utilization,
+                resetsAt: parseDate(bucket.resets_at)
+            ))
+        }
+
         return ProviderUsageSnapshot(provider: "Claude", lastUpdated: Date(), windows: windows, error: nil)
     }
 }

--- a/src/Sources/CodexUsageProbe.swift
+++ b/src/Sources/CodexUsageProbe.swift
@@ -1,56 +1,6 @@
 import Foundation
 
 class CodexUsageProbe {
-    struct JSONRPCRequest: Codable {
-        let jsonrpc: String
-        let id: Int
-        let method: String
-        let params: [String: String]?
-    }
-
-    struct JSONRPCNotification: Codable {
-        let jsonrpc: String
-        let method: String
-    }
-
-    struct JSONRPCResponse: Codable {
-        let jsonrpc: String
-        let id: Int
-        let result: [String: AnyCodable]?
-        let error: AnyCodable?
-    }
-
-    struct AnyCodable: Codable {
-        let value: Any
-        
-        init(_ value: Any) {
-            self.value = value
-        }
-        
-        init(from decoder: Decoder) throws {
-            let container = try decoder.singleValueContainer()
-            if let intVal = try? container.decode(Int.self) { value = intVal }
-            else if let doubleVal = try? container.decode(Double.self) { value = doubleVal }
-            else if let stringVal = try? container.decode(String.self) { value = stringVal }
-            else if let boolVal = try? container.decode(Bool.self) { value = boolVal }
-            else if let dictVal = try? container.decode([String: AnyCodable].self) {
-                var dict = [String: Any]()
-                for (k, v) in dictVal { dict[k] = v.value }
-                value = dict
-            }
-            else { throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyCodable unsupported type") }
-        }
-        
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.singleValueContainer()
-            if let intVal = value as? Int { try container.encode(intVal) }
-            else if let doubleVal = value as? Double { try container.encode(doubleVal) }
-            else if let stringVal = value as? String { try container.encode(stringVal) }
-            else if let boolVal = value as? Bool { try container.encode(boolVal) }
-            else { throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: encoder.codingPath, debugDescription: "AnyCodable unsupported type")) }
-        }
-    }
-
     func fetchUsage() async -> ProviderUsageSnapshot {
         do {
             if !codexCLIInstalled() {
@@ -66,9 +16,13 @@ class CodexUsageProbe {
         let task = Process()
         task.launchPath = "/bin/sh"
         task.arguments = ["-c", "which codex"]
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.launch()
+        task.standardOutput = Pipe()
+        task.standardError = Pipe()
+        do {
+            try task.run()
+        } catch {
+            return false
+        }
         task.waitUntilExit()
         return task.terminationStatus == 0
     }
@@ -77,69 +31,79 @@ class CodexUsageProbe {
         let task = Process()
         task.launchPath = "/bin/sh"
         let home = FileManager.default.homeDirectoryForCurrentUser.path
-        // Augment PATH just in case it's in homebrew or local bin
         task.arguments = ["-c", "PATH=$PATH:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin codex -s read-only -a untrusted app-server"]
         task.currentDirectoryPath = home
-        
+
         let pipeOut = Pipe()
         let pipeIn = Pipe()
         task.standardOutput = pipeOut
         task.standardInput = pipeIn
-        
+        task.standardError = Pipe()
+
         try task.run()
-        
-        // Send initialize
-        let initReq = JSONRPCRequest(jsonrpc: "2.0", id: 1, method: "initialize", params: nil)
-        let initData = try JSONEncoder().encode(initReq)
-        let initStr = String(data: initData, encoding: .utf8)!
-        let initHeader = "Content-Length: \(initData.count)\r\n\r\n"
-        try pipeIn.fileHandleForWriting.write(contentsOf: Data((initHeader + initStr).utf8))
-        
-        // Read initialized / respond
-        // This is a simplified sequential read just to grab the rateLimits after initialization
-        
-        // Wait briefly for init to process, then send read request
+
+        let initLine = #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"droidproxy","version":"1.0.0"}}}"# + "\n"
+        try pipeIn.fileHandleForWriting.write(contentsOf: Data(initLine.utf8))
+
         try await Task.sleep(nanoseconds: 500_000_000)
-        
-        let readReq = JSONRPCRequest(jsonrpc: "2.0", id: 2, method: "account/rateLimits/read", params: nil)
-        let readData = try JSONEncoder().encode(readReq)
-        let readStr = String(data: readData, encoding: .utf8)!
-        let readHeader = "Content-Length: \(readData.count)\r\n\r\n"
-        try pipeIn.fileHandleForWriting.write(contentsOf: Data((readHeader + readStr).utf8))
-        
-        // Wait for response
-        try await Task.sleep(nanoseconds: 1_000_000_000)
-        
-        // Terminate so we can read whatever was buffered
+
+        let readLine = #"{"jsonrpc":"2.0","id":2,"method":"account/rateLimits/read","params":{}}"# + "\n"
+        try pipeIn.fileHandleForWriting.write(contentsOf: Data(readLine.utf8))
+
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+
         task.terminate()
         let outData = pipeOut.fileHandleForReading.readDataToEndOfFile()
         let outStr = String(data: outData, encoding: .utf8) ?? ""
-        
-        // Parse JSON-RPC responses (quick hack: find the result object for id 2)
+
         var windows = [UsageWindow]()
-        let components = outStr.components(separatedBy: "Content-Length: ")
-        for comp in components {
-            if let range = comp.range(of: "\r\n\r\n") {
-                let jsonStr = String(comp[range.upperBound...])
-                if let data = jsonStr.data(using: .utf8),
-                   let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-                   let id = json["id"] as? Int, id == 2,
-                   let result = json["result"] as? [String: Any],
-                   let rateLimits = result["rateLimits"] as? [String: Any] {
-                    
-                    if let primary = rateLimits["primary"] as? [String: Any],
-                       let percent = primary["usedPercent"] as? Double {
-                        windows.append(UsageWindow(kind: .other, limit: 100, used: Int(percent), percentUsed: percent, resetsAt: Date().addingTimeInterval(4*3600))) // Placeholder limit/resets
-                    }
-                    if let secondary = rateLimits["secondary"] as? [String: Any],
-                       let percent = secondary["usedPercent"] as? Double {
-                        windows.append(UsageWindow(kind: .weekly, limit: 100, used: Int(percent), percentUsed: percent, resetsAt: nil))
-                    }
-                    break
-                }
+        var parseError: String? = nil
+
+        for line in outStr.split(separator: "\n") {
+            guard let data = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+                continue
             }
+            guard let id = json["id"] as? Int, id == 2 else { continue }
+
+            if let err = json["error"] as? [String: Any] {
+                parseError = (err["message"] as? String) ?? "Unknown JSON-RPC error"
+                break
+            }
+
+            guard let result = json["result"] as? [String: Any],
+                  let rateLimits = result["rateLimits"] as? [String: Any] else {
+                continue
+            }
+
+            windows.append(contentsOf: Self.parseWindows(from: rateLimits))
+            break
         }
-        
-        return ProviderUsageSnapshot(provider: "Codex", lastUpdated: Date(), windows: windows, error: windows.isEmpty ? "Failed to parse rate limits" : nil)
+
+        let error: String? = {
+            if let parseError { return parseError }
+            return windows.isEmpty ? "Failed to parse rate limits" : nil
+        }()
+
+        return ProviderUsageSnapshot(provider: "Codex", lastUpdated: Date(), windows: windows, error: error)
+    }
+
+    private static func parseWindows(from rateLimits: [String: Any]) -> [UsageWindow] {
+        var windows = [UsageWindow]()
+        for (key, kind) in [("primary", UsageWindowKind.other), ("secondary", UsageWindowKind.weekly)] {
+            guard let bucket = rateLimits[key] as? [String: Any],
+                  let percent = (bucket["usedPercent"] as? NSNumber)?.doubleValue else {
+                continue
+            }
+            let durationMins = (bucket["windowDurationMins"] as? NSNumber)?.doubleValue
+            let resetsAtEpoch = (bucket["resetsAt"] as? NSNumber)?.doubleValue
+            let resetsAt: Date? = {
+                if let resetsAtEpoch { return Date(timeIntervalSince1970: resetsAtEpoch) }
+                if let durationMins { return Date().addingTimeInterval(durationMins * 60) }
+                return nil
+            }()
+            windows.append(UsageWindow(kind: kind, limit: 100, used: Int(percent.rounded()), percentUsed: percent, resetsAt: resetsAt))
+        }
+        return windows
     }
 }

--- a/src/Sources/CodexUsageProbe.swift
+++ b/src/Sources/CodexUsageProbe.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+class CodexUsageProbe {
+    struct JSONRPCRequest: Codable {
+        let jsonrpc: String
+        let id: Int
+        let method: String
+        let params: [String: String]?
+    }
+
+    struct JSONRPCNotification: Codable {
+        let jsonrpc: String
+        let method: String
+    }
+
+    struct JSONRPCResponse: Codable {
+        let jsonrpc: String
+        let id: Int
+        let result: [String: AnyCodable]?
+        let error: AnyCodable?
+    }
+
+    struct AnyCodable: Codable {
+        let value: Any
+        
+        init(_ value: Any) {
+            self.value = value
+        }
+        
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let intVal = try? container.decode(Int.self) { value = intVal }
+            else if let doubleVal = try? container.decode(Double.self) { value = doubleVal }
+            else if let stringVal = try? container.decode(String.self) { value = stringVal }
+            else if let boolVal = try? container.decode(Bool.self) { value = boolVal }
+            else if let dictVal = try? container.decode([String: AnyCodable].self) {
+                var dict = [String: Any]()
+                for (k, v) in dictVal { dict[k] = v.value }
+                value = dict
+            }
+            else { throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyCodable unsupported type") }
+        }
+        
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            if let intVal = value as? Int { try container.encode(intVal) }
+            else if let doubleVal = value as? Double { try container.encode(doubleVal) }
+            else if let stringVal = value as? String { try container.encode(stringVal) }
+            else if let boolVal = value as? Bool { try container.encode(boolVal) }
+            else { throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: encoder.codingPath, debugDescription: "AnyCodable unsupported type")) }
+        }
+    }
+
+    func fetchUsage() async -> ProviderUsageSnapshot {
+        do {
+            if !codexCLIInstalled() {
+                return ProviderUsageSnapshot(provider: "Codex", lastUpdated: Date(), windows: [], error: "Codex CLI not installed")
+            }
+            return try await executeJSONRPC()
+        } catch {
+            return ProviderUsageSnapshot(provider: "Codex", lastUpdated: Date(), windows: [], error: error.localizedDescription)
+        }
+    }
+
+    private func codexCLIInstalled() -> Bool {
+        let task = Process()
+        task.launchPath = "/bin/sh"
+        task.arguments = ["-c", "which codex"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.launch()
+        task.waitUntilExit()
+        return task.terminationStatus == 0
+    }
+
+    private func executeJSONRPC() async throws -> ProviderUsageSnapshot {
+        let task = Process()
+        task.launchPath = "/bin/sh"
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        // Augment PATH just in case it's in homebrew or local bin
+        task.arguments = ["-c", "PATH=$PATH:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin codex -s read-only -a untrusted app-server"]
+        task.currentDirectoryPath = home
+        
+        let pipeOut = Pipe()
+        let pipeIn = Pipe()
+        task.standardOutput = pipeOut
+        task.standardInput = pipeIn
+        
+        try task.run()
+        
+        // Send initialize
+        let initReq = JSONRPCRequest(jsonrpc: "2.0", id: 1, method: "initialize", params: nil)
+        let initData = try JSONEncoder().encode(initReq)
+        let initStr = String(data: initData, encoding: .utf8)!
+        let initHeader = "Content-Length: \(initData.count)\r\n\r\n"
+        try pipeIn.fileHandleForWriting.write(contentsOf: Data((initHeader + initStr).utf8))
+        
+        // Read initialized / respond
+        // This is a simplified sequential read just to grab the rateLimits after initialization
+        
+        // Wait briefly for init to process, then send read request
+        try await Task.sleep(nanoseconds: 500_000_000)
+        
+        let readReq = JSONRPCRequest(jsonrpc: "2.0", id: 2, method: "account/rateLimits/read", params: nil)
+        let readData = try JSONEncoder().encode(readReq)
+        let readStr = String(data: readData, encoding: .utf8)!
+        let readHeader = "Content-Length: \(readData.count)\r\n\r\n"
+        try pipeIn.fileHandleForWriting.write(contentsOf: Data((readHeader + readStr).utf8))
+        
+        // Wait for response
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        // Terminate so we can read whatever was buffered
+        task.terminate()
+        let outData = pipeOut.fileHandleForReading.readDataToEndOfFile()
+        let outStr = String(data: outData, encoding: .utf8) ?? ""
+        
+        // Parse JSON-RPC responses (quick hack: find the result object for id 2)
+        var windows = [UsageWindow]()
+        let components = outStr.components(separatedBy: "Content-Length: ")
+        for comp in components {
+            if let range = comp.range(of: "\r\n\r\n") {
+                let jsonStr = String(comp[range.upperBound...])
+                if let data = jsonStr.data(using: .utf8),
+                   let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                   let id = json["id"] as? Int, id == 2,
+                   let result = json["result"] as? [String: Any],
+                   let rateLimits = result["rateLimits"] as? [String: Any] {
+                    
+                    if let primary = rateLimits["primary"] as? [String: Any],
+                       let percent = primary["usedPercent"] as? Double {
+                        windows.append(UsageWindow(kind: .other, limit: 100, used: Int(percent), percentUsed: percent, resetsAt: Date().addingTimeInterval(4*3600))) // Placeholder limit/resets
+                    }
+                    if let secondary = rateLimits["secondary"] as? [String: Any],
+                       let percent = secondary["usedPercent"] as? Double {
+                        windows.append(UsageWindow(kind: .weekly, limit: 100, used: Int(percent), percentUsed: percent, resetsAt: nil))
+                    }
+                    break
+                }
+            }
+        }
+        
+        return ProviderUsageSnapshot(provider: "Codex", lastUpdated: Date(), windows: windows, error: windows.isEmpty ? "Failed to parse rate limits" : nil)
+    }
+}

--- a/src/Sources/CodexUsageProbe.swift
+++ b/src/Sources/CodexUsageProbe.swift
@@ -102,7 +102,7 @@ class CodexUsageProbe {
                 if let durationMins { return Date().addingTimeInterval(durationMins * 60) }
                 return nil
             }()
-            windows.append(UsageWindow(kind: kind, limit: 100, used: Int(percent.rounded()), percentUsed: percent, resetsAt: resetsAt))
+            windows.append(UsageWindow(kind: kind, limit: 0, used: 0, percentUsed: percent, resetsAt: resetsAt))
         }
         return windows
     }

--- a/src/Sources/NotificationNames.swift
+++ b/src/Sources/NotificationNames.swift
@@ -3,4 +3,5 @@ import Foundation
 extension Notification.Name {
     static let serverStatusChanged = Notification.Name("ServerStatusChanged")
     static let authDirectoryChanged = Notification.Name("AuthDirectoryChanged")
+    static let usageUpdated = Notification.Name("UsageUpdated")
 }

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -521,6 +521,8 @@ struct SettingsView: View {
     @AppStorage(AppPreferences.allowRemoteKey) private var allowRemote = AppPreferences.defaultAllowRemote
     @AppStorage(AppPreferences.secretKeyKey) private var secretKey = AppPreferences.defaultSecretKey
     @AppStorage(AppPreferences.claudeMaxBudgetModeKey) private var claudeMaxBudgetMode = AppPreferences.defaultClaudeMaxBudgetMode
+    @AppStorage(AppPreferences.showUsageInMenuBarKey) private var showUsageInMenuBar = AppPreferences.defaultShowUsageInMenuBar
+    @AppStorage(AppPreferences.usageAutoRefreshSecondsKey) private var usageAutoRefreshSeconds = AppPreferences.defaultUsageAutoRefreshSeconds
     @AppStorage(AppPreferences.oledThemeKey) private var oledTheme = AppPreferences.defaultOledTheme
     @AppStorage(AppPreferences.factoryAdvancedModelsKey) private var factoryAdvancedModels = AppPreferences.defaultFactoryAdvancedModels
     @State private var authenticatingService: ServiceType? = nil
@@ -736,6 +738,39 @@ struct SettingsView: View {
                             applyChallengerPlugin()
                         }
                         .droidGlassProminent()
+                        .controlSize(.small)
+                    }
+                }
+                .listRowBackground(glassRowBackground)
+
+                Section {
+                    Toggle("Show usage in menu bar", isOn: $showUsageInMenuBar)
+                        .onChange(of: showUsageInMenuBar) { _ in
+                            NotificationCenter.default.post(name: .usageUpdated, object: nil)
+                        }
+                    
+                    HStack {
+                        Text("Auto-refresh usage")
+                        Spacer()
+                        Picker("", selection: $usageAutoRefreshSeconds) {
+                            Text("Manual").tag(0)
+                            Text("1 minute").tag(60)
+                            Text("5 minutes").tag(300)
+                            Text("10 minutes").tag(600)
+                            Text("30 minutes").tag(1800)
+                        }
+                        .pickerStyle(.menu)
+                        .frame(width: 120)
+                        .onChange(of: usageAutoRefreshSeconds) { _ in
+                            UsageStore.shared.scheduleTimer()
+                        }
+                    }
+                    
+                    HStack {
+                        Spacer()
+                        Button("Refresh now") {
+                            UsageStore.shared.refresh()
+                        }
                         .controlSize(.small)
                     }
                 }

--- a/src/Sources/UsageModels.swift
+++ b/src/Sources/UsageModels.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum UsageWindowKind: String, Codable {
+    case hourly
+    case daily
+    case weekly
+    case monthly
+    case other
+}
+
+struct UsageWindow: Codable {
+    let kind: UsageWindowKind
+    let limit: Int
+    let used: Int
+    let percentUsed: Double // 0-100
+    let resetsAt: Date?
+}
+
+struct ProviderUsageSnapshot: Codable {
+    let provider: String // "Claude" or "Codex"
+    let lastUpdated: Date
+    let windows: [UsageWindow]
+    let error: String?
+}

--- a/src/Sources/UsageStore.swift
+++ b/src/Sources/UsageStore.swift
@@ -6,41 +6,47 @@ class UsageStore: ObservableObject {
     @Published var codexUsage: ProviderUsageSnapshot?
     
     private var timer: Timer?
+    private var refreshTask: Task<Void, Never>?
     private let claudeProbe = ClaudeUsageProbe()
     private let codexProbe = CodexUsageProbe()
-    
+
     static let shared = UsageStore()
-    
+
     init() {}
-    
+
     func start() {
         refresh()
         scheduleTimer()
     }
-    
+
     func stop() {
         timer?.invalidate()
         timer = nil
+        refreshTask?.cancel()
+        refreshTask = nil
     }
-    
+
     func refresh() {
-        Task {
+        refreshTask?.cancel()
+        refreshTask = Task { [weak self] in
+            guard let self else { return }
             async let claude = claudeProbe.fetchUsage()
             async let codex = codexProbe.fetchUsage()
-            
+
             let (cUsage, cxUsage) = await (claude, codex)
-            
-            await MainActor.run {
-                self.claudeUsage = cUsage
-                self.codexUsage = cxUsage
-                NotificationCenter.default.post(name: .usageUpdated, object: nil)
-            }
+            guard !Task.isCancelled else { return }
+
+            self.claudeUsage = cUsage
+            self.codexUsage = cxUsage
+            NotificationCenter.default.post(name: .usageUpdated, object: nil)
         }
     }
-    
+
     func scheduleTimer() {
         timer?.invalidate()
+        timer = nil
         let interval = Double(AppPreferences.usageAutoRefreshSeconds)
+        guard interval > 0 else { return }
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 self?.refresh()

--- a/src/Sources/UsageStore.swift
+++ b/src/Sources/UsageStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+@MainActor
+class UsageStore: ObservableObject {
+    @Published var claudeUsage: ProviderUsageSnapshot?
+    @Published var codexUsage: ProviderUsageSnapshot?
+    
+    private var timer: Timer?
+    private let claudeProbe = ClaudeUsageProbe()
+    private let codexProbe = CodexUsageProbe()
+    
+    static let shared = UsageStore()
+    
+    init() {}
+    
+    func start() {
+        refresh()
+        scheduleTimer()
+    }
+    
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+    
+    func refresh() {
+        Task {
+            async let claude = claudeProbe.fetchUsage()
+            async let codex = codexProbe.fetchUsage()
+            
+            let (cUsage, cxUsage) = await (claude, codex)
+            
+            await MainActor.run {
+                self.claudeUsage = cUsage
+                self.codexUsage = cxUsage
+                NotificationCenter.default.post(name: .usageUpdated, object: nil)
+            }
+        }
+    }
+    
+    func scheduleTimer() {
+        timer?.invalidate()
+        let interval = Double(AppPreferences.usageAutoRefreshSeconds)
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.refresh()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR surfaces your Claude and Codex rate limit usage directly in DroidProxy, giving you quick visibility into your 5-hour and weekly budgets.

**What's new for users**

- **Usage in the dropdown.** Click the menu bar icon to see your current Claude and Codex usage as percentages — the 5h window, the weekly window, and when the 5h window resets. The status bar stays icon-only so it doesn't clutter your menu bar.
- **Refresh controls.** Usage auto-refreshes every 5 minutes by default, or whenever your Mac wakes from sleep. You can manually refresh from the menu or configure the interval in Settings.

**Behind the scenes**

- Added `ClaudeUsageProbe` to hit Anthropic's `/api/oauth/usage` endpoint, automatically refreshing tokens in `~/.cli-proxy-api/claude-*.json` when needed. Token expiration is parsed from the ISO timestamp stored in the auth file, and the response is decoded against the actual flat-keyed shape (`five_hour`, `seven_day_*` buckets with `utilization` + `resets_at`).
- Added `CodexUsageProbe` to spawn `codex app-server` and query its JSON-RPC `account/rateLimits/read` method. Uses line-delimited JSON framing (which is what `codex app-server` actually speaks) and passes the required `clientInfo` on initialize.
- Added `UsageStore` to coordinate parallel fetching and broadcast updates to the UI.
- Wired up a new Settings section to configure auto-refresh timing.

## Testing

- Built locally and verified the dropdown shows real percentages once the probes complete (`5h: 30%` for Claude, `5h: 100%` for Codex on a rate-limited account).
- Confirmed the "Refresh Usage" menu item triggers a fetch.
- Confirmed settings changes update the refresh interval.
- Confirmed the menu bar icon stays text-free.