### PR TITLE
Fix Codex CLI detection using expanded PATH

### DIFF
--- a/src/Sources/CodexUsageProbe.swift
+++ b/src/Sources/CodexUsageProbe.swift
@@ -15,7 +15,7 @@ class CodexUsageProbe {
     private func codexCLIInstalled() -> Bool {
         let task = Process()
         task.launchPath = "/bin/sh"
-        task.arguments = ["-c", "which codex"]
+        task.arguments = ["-c", "PATH=$PATH:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin which codex"]
         task.standardOutput = Pipe()
         task.standardError = Pipe()
         do {


### PR DESCRIPTION
## Summary
`codexCLIInstalled()` was checking for the `codex` binary using the bare macOS GUI-app PATH (`/usr/bin:/bin`), while `executeJSONRPC()` augmented PATH with `/opt/homebrew/bin:/usr/local/bin:~/.local/bin`. This caused the usage probe to report "Codex CLI not installed" even when codex was available at one of those paths.

Fixed by using the same expanded PATH in the installation check.

---
[Warp conversation](https://app.warp.dev/conversation/e6f76647-db9e-4dc8-9611-8861451e69cd)