### PR TITLE
Restore Claude thinking traces!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Fixed
+- **Claude thinking display** -- DroidProxy now requests summarized Opus 4.7 thinking and removes the `redact-thinking-2026-02-12` beta for Claude thinking requests so Anthropic streams plaintext `thinking_delta` blocks instead of empty thinking blocks with only signatures.
 - **Codex `auth_unavailable` blackout during long sessions** ([#57](https://github.com/anand-92/droidproxy/issues/57)) -- Bundled `config.yaml` now sets `disable-cooling: true` so a single transient failure on a Codex/Claude/Gemini auth no longer parks every available account behind a cooldown window. Long Factory/Droid sessions on `gpt-5.5`, `gpt-5.4`, etc. no longer fail with `503 auth_unavailable: no auth available (providers=codex,github-copilot)` after working normally for hours.
 - **Encrypted reasoning state mismatch on `/v1/responses`** ([#58](https://github.com/anand-92/droidproxy/issues/58)) -- Bundled `config.yaml` now enables `routing.session-affinity: true` (TTL `2h`). Stateful Codex Responses API turns now stay pinned to the same upstream auth, so encrypted reasoning content created on turn N is no longer replayed through a different account on turn N+1 with `400 The encrypted content ... could not be verified`.
 

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -5,7 +5,7 @@ import Network
  A lightweight HTTP proxy that injects reasoning settings for supported Claude and Codex GPT models.
 
  Current behavior:
- - Requests whose `model` contains `opus-4-7` receive `thinking: {"type":"adaptive"}`
+ - Requests whose `model` contains `opus-4-7` receive `thinking: {"type":"adaptive","display":"summarized"}`
    plus `output_config.effort` from `AppPreferences.opus47ThinkingEffort`
  - Requests whose `model` contains `opus-4-6` receive `thinking: {"type":"adaptive"}`
    plus `output_config.effort` from `AppPreferences.opus46ThinkingEffort`
@@ -14,6 +14,8 @@ import Network
    `AppPreferences.opus45ThinkingEffort` (Opus 4.5 does not support adaptive thinking).
  - Requests whose `model` contains `sonnet-4-6` receive `thinking: {"type":"adaptive"}`
    plus `output_config.effort` from `AppPreferences.sonnet46ThinkingEffort`
+ - Claude requests with thinking enabled forward an Anthropic-Beta header that omits
+   `redact-thinking-2026-02-12`, otherwise Claude emits only signed empty thinking blocks.
  - Requests whose `model` is exactly `gpt-5.3-codex` receive `reasoning: {"effort":"..."}`
    from `AppPreferences.gpt53CodexReasoningEffort`
 - Requests whose `model` is exactly `gpt-5.4` or `gpt-5.5` receive `reasoning: {"effort":"..."}`
@@ -54,6 +56,17 @@ class ThinkingProxy {
 
     private enum Config {
         static let anthropicVersion = "2023-06-01"
+        static let claudeRedactedThinkingBeta = "redact-thinking-2026-02-12"
+        static let claudeVisibleThinkingBetas = [
+            "claude-code-20250219",
+            "oauth-2025-04-20",
+            "interleaved-thinking-2025-05-14",
+            "context-management-2025-06-27",
+            "prompt-caching-scope-2026-01-05",
+            "structured-outputs-2025-12-15",
+            "fast-mode-2026-02-01",
+            "token-efficient-tools-2026-03-28"
+        ]
     }
     
     /**
@@ -300,7 +313,72 @@ class ThinkingProxy {
             rewrittenPath = newPath
         }
 
-        forwardRequest(method: method, path: rewrittenPath, version: httpVersion, headers: headers, body: modifiedBody, originalConnection: connection)
+        let forwardHeaders = headersForForwarding(headers, bodyString: modifiedBody)
+        forwardRequest(method: method, path: rewrittenPath, version: httpVersion, headers: forwardHeaders, body: modifiedBody, originalConnection: connection)
+    }
+
+    private func headersForForwarding(_ headers: [(String, String)], bodyString: String) -> [(String, String)] {
+        guard shouldRequestVisibleClaudeThinking(bodyString: bodyString) else {
+            return headers
+        }
+
+        ThinkingProxy.fileLog("CLAUDE visible thinking enabled: removing \(Config.claudeRedactedThinkingBeta) from Anthropic-Beta")
+        return headersWithVisibleClaudeThinkingBetas(headers)
+    }
+
+    private func shouldRequestVisibleClaudeThinking(bodyString: String) -> Bool {
+        guard let jsonData = bodyString.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+              let model = json["model"] as? String,
+              isClaudeModel(model),
+              let thinking = json["thinking"] as? [String: Any],
+              let thinkingType = thinking["type"] as? String else {
+            return false
+        }
+
+        switch thinkingType {
+        case "enabled", "adaptive", "auto":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func isClaudeModel(_ model: String) -> Bool {
+        model.starts(with: "claude-") || model.starts(with: "gemini-claude-")
+    }
+
+    private func headersWithVisibleClaudeThinkingBetas(_ headers: [(String, String)]) -> [(String, String)] {
+        var forwardedHeaders: [(String, String)] = []
+        var betaCandidates: [String] = []
+
+        for (name, value) in headers {
+            if name.caseInsensitiveCompare("anthropic-beta") == .orderedSame {
+                betaCandidates.append(contentsOf: parseAnthropicBetas(value))
+                continue
+            }
+            forwardedHeaders.append((name, value))
+        }
+
+        betaCandidates.append(contentsOf: Config.claudeVisibleThinkingBetas)
+
+        var seen = Set<String>()
+        let visibleBetas = betaCandidates.compactMap { rawBeta -> String? in
+            let beta = rawBeta.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !beta.isEmpty else { return nil }
+            let normalizedBeta = beta.lowercased()
+            guard normalizedBeta != Config.claudeRedactedThinkingBeta else { return nil }
+            guard !seen.contains(normalizedBeta) else { return nil }
+            seen.insert(normalizedBeta)
+            return beta
+        }
+
+        forwardedHeaders.append(("Anthropic-Beta", visibleBetas.joined(separator: ",")))
+        return forwardedHeaders
+    }
+
+    private func parseAnthropicBetas(_ value: String) -> [String] {
+        value.split(separator: ",").map { String($0) }
     }
 
     /**
@@ -424,8 +502,11 @@ class ThinkingProxy {
             NSLog("[ThinkingProxy] Injected classic budget_tokens max mode for '\(model)' budget=\(budgetTokens) max_tokens=\(maxTokens)")
             ThinkingProxy.fileLog("INJECTED classic budget_tokens max mode: budget_tokens=\(budgetTokens) max_tokens=\(maxTokens) for model \(model)")
         } else {
+            let thinkingValue = isOpus47Model(model)
+                ? "{\"type\":\"adaptive\",\"display\":\"summarized\"}"
+                : "{\"type\":\"adaptive\"}"
             result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "thinking",
-                                              fieldValue: "{\"type\":\"adaptive\"}",
+                                              fieldValue: thinkingValue,
                                               existsInJSON: json["thinking"] != nil)
             result = replaceOrInjectJSONField(in: result, afterKey: "thinking", fieldName: "output_config",
                                               fieldValue: "{\"effort\":\"\(effort)\"}",
@@ -550,6 +631,10 @@ class ThinkingProxy {
             return AppPreferences.sonnet46ThinkingEffort
         }
         return nil
+    }
+
+    private func isOpus47Model(_ model: String) -> Bool {
+        model.contains("opus-4-7")
     }
 
     /// Matches Opus 4.5 (`claude-opus-4-5`, `gemini-claude-opus-4-5`, date-suffixed variants)


### PR DESCRIPTION
## Summary

This PR makes Claude thinking visible in DroidProxy streams instead of forwarding signed empty thinking blocks.

**What's new for users**

- **Claude thoughts now show up live.** Claude requests with thinking enabled now stream plaintext `thinking_delta` events so Droid CLI sessions can show the model reasoning naturally.

**Behind the scenes**

- Requests Opus 4.7 summarized thinking with `thinking.display: "summarized"`.
- Removes the `redact-thinking-2026-02-12` beta from Claude thinking requests while preserving/deduplicating the visible Claude Code beta set.
- Leaves GPT/Codex reasoning behavior unchanged.

## Testing

- `swift build`
- Rebuilt and launched `DroidProxy.app` with `./create-app-bundle.sh`.
- Verified a plain `/v1/messages` Claude request through `localhost:8317` streams `content_block_delta` events with `delta.type: "thinking_delta"`.
