### PR TITLE
Add GPT 5.2 model and switch GPT challenger to it

### DIFF
--- a/.factory/droids/challenger-gpt.md
+++ b/.factory/droids/challenger-gpt.md
@@ -1,7 +1,7 @@
 ---
 name: challenger-gpt
 description: Devil's advocate code reviewer that challenges decisions, critiques patterns, and suggests better alternatives. Use when you want a tough second opinion on code, architecture, or design choices.
-model: custom:droidproxy:gpt-5.4
+model: custom:droidproxy:gpt-5.2
 tools: ["Read", "LS", "Grep", "Glob", "WebSearch", "FetchUrl"]
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+- **GPT 5.2 model** -- New Codex model exposed end-to-end: per-model reasoning effort picker (`low` / `medium` / `high` / `xhigh`, default `high`), Fast Mode toggle (`service_tier=priority` on `/v1/responses` and `/api/v1/responses`), and Factory custom-models entry `custom:droidproxy:gpt-5.2`. Click Apply Factory Models again after upgrading to provision it into `~/.factory/settings.json`.
+
+### Changed
+- **Challenger GPT droid now runs on GPT 5.2** -- Both the project-level `.factory/droids/challenger-gpt.md` (previously `gpt-5.4`) and the droid installed via Apply Challenger Plugin (previously `gpt-5.5`) are unified on `custom:droidproxy:gpt-5.2`. Rationale comes from Factory's [code review benchmark](https://factory.ai/news/code-review-benchmark):
+  > A note on GPT-5.4 and GPT-5.5: both underperform GPT-5.2, but for opposite reasons. GPT-5.4 is too conservative -- it comments sparingly (2.5/PR vs the 3.2 golden average) with decent precision (56.8%) but misses too many real bugs (42.4% recall). GPT-5.5 swings the other way: it comments at the right rate (3.5/PR) but nearly half are false positives (47.5% precision). In our experiments, GPT-5.4 needs explicit severity filters and strict constraints to stay focused, while GPT-5.5 needs tighter validation to filter out noise. Models like GPT-5.2 are more naturally calibrated with general-purpose prompts, which is why they outperform both in a standardized benchmark.
+  >
+  > Top-tier quality at half the cost of Opus 4.6.
+
 ### Fixed
 - **Claude thinking display** -- DroidProxy now requests summarized Opus 4.7 thinking and removes the `redact-thinking-2026-02-12` beta for Claude thinking requests so Anthropic streams plaintext `thinking_delta` blocks instead of empty thinking blocks with only signatures.
 - **Codex `auth_unavailable` blackout during long sessions** ([#57](https://github.com/anand-92/droidproxy/issues/57)) -- Bundled `config.yaml` now sets `disable-cooling: true` so a single transient failure on a Codex/Claude/Gemini auth no longer parks every available account behind a cooldown window. Long Factory/Droid sessions on `gpt-5.5`, `gpt-5.4`, etc. no longer fail with `503 auth_unavailable: no auth available (providers=codex,github-copilot)` after working normally for hours.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All releases are code-signed and notarized by Apple. Existing installs auto-upda
 ## Features
 
 - **One-click OAuth auth** -- Claude Code, Codex, Gemini, and Kimi login from the menu bar, credential monitoring, auto-refresh
-- **Per-model reasoning/effort controls** -- Configure Opus 4.7, Sonnet 4.6, GPT 5.3 Codex, GPT 5.4, GPT 5.5, Gemini 3.1 Pro, Gemini 3 Flash, and Kimi K2.6 directly from the Settings window. Also supports `fast` mode for gpt models.
+- **Per-model reasoning/effort controls** -- Configure Opus 4.7, Sonnet 4.6, GPT 5.2, GPT 5.3 Codex, GPT 5.4, GPT 5.5, Gemini 3.1 Pro, Gemini 3 Flash, and Kimi K2.6 directly from the Settings window. Also supports `fast` mode for gpt models.
 - **Max Budget Mode** -- Nuclear launch button that forces maximum reasoning on Opud/Sonnet 4.6 requests: classic extended thinking with `budget_tokens: 63999`, `max_tokens: 64000`, and `effort: max`. Opus 4.7 does not need this override. Full thinking power for Sonnet, your quota's problem.
 - **Usage tracking** -- Live Claude and Codex rate limit windows (5-hour + weekly) in the menu bar dropdown. Auto-refreshes every 5 minutes (configurable) and on Mac wake. Codex tracking requires the `codex` CLI to be installed and logged in (`codex login`).
 
@@ -78,7 +78,9 @@ src/
 
 ## Challenger Droids - 1 Click Install via UI
 
-DroidProxy ships with three devil's advocate code reviewer droids -- powered by Claude Opus 4.7, GPT 5.5, and Gemini 3.1 Pro. They challenge your code decisions, surface tradeoffs you may have missed, stress-test edge cases, and suggest concrete alternatives. Running multiple gives you a cross-model second opinion that catches blind spots a single reviewer might miss.
+DroidProxy ships with three devil's advocate code reviewer droids -- powered by Claude Opus 4.7, GPT 5.2, and Gemini 3.1 Pro. They challenge your code decisions, surface tradeoffs you may have missed, stress-test edge cases, and suggest concrete alternatives. Running multiple gives you a cross-model second opinion that catches blind spots a single reviewer might miss.
+
+GPT 5.2 is the chosen workhorse here because Factory's [code review benchmark](https://factory.ai/news/code-review-benchmark) found it more naturally calibrated than GPT-5.4 (too conservative, misses real bugs) and GPT-5.5 (too noisy, ~47% false positives) -- "top-tier quality at half the cost of Opus 4.6".
 
 
 ### Usage
@@ -86,7 +88,7 @@ DroidProxy ships with three devil's advocate code reviewer droids -- powered by 
 In any Droid session, use the slash commands:
 
 - `/challenge-opus` -- summon the Claude Opus 4.7 challenger
-- `/challenge-gpt` -- summon the GPT 5.5 challenger
+- `/challenge-gpt` -- summon the GPT 5.2 challenger
 - `/challenge-gemini` -- summon the Gemini 3.1 Pro challenger
 
 Both droids are read-only (no file edits) and return a structured verdict with challenges, edge cases, and acknowledgements of what's solid.

--- a/SETUP.md
+++ b/SETUP.md
@@ -35,9 +35,20 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
       "provider": "anthropic"
     },
     {
+      "model": "gpt-5.2",
+      "id": "custom:droidproxy:gpt-5.2",
+      "index": 2,
+      "baseUrl": "http://localhost:8317/v1",
+      "apiKey": "dummy-not-used",
+      "displayName": "DroidProxy: GPT 5.2",
+      "maxOutputTokens": 128000,
+      "noImageSupport": false,
+      "provider": "openai"
+    },
+    {
       "model": "gpt-5.3-codex",
       "id": "custom:droidproxy:gpt-5.3-codex",
-      "index": 2,
+      "index": 3,
       "baseUrl": "http://localhost:8317/v1",
       "apiKey": "dummy-not-used",
       "displayName": "DroidProxy: GPT 5.3 Codex",
@@ -48,7 +59,7 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
     {
       "model": "gpt-5.4",
       "id": "custom:droidproxy:gpt-5.4",
-      "index": 3,
+      "index": 4,
       "baseUrl": "http://localhost:8317/v1",
       "apiKey": "dummy-not-used",
       "displayName": "DroidProxy: GPT 5.4",
@@ -59,7 +70,7 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
     {
       "model": "gpt-5.5",
       "id": "custom:droidproxy:gpt-5.5",
-      "index": 4,
+      "index": 5,
       "baseUrl": "http://localhost:8317/v1",
       "apiKey": "dummy-not-used",
       "displayName": "DroidProxy: GPT 5.5",
@@ -70,7 +81,7 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
     {
       "model": "gemini-3.1-pro-preview",
       "id": "custom:droidproxy:gemini-3.1-pro",
-      "index": 5,
+      "index": 6,
       "baseUrl": "http://localhost:8317",
       "apiKey": "dummy-not-used",
       "displayName": "DroidProxy: Gemini 3.1 Pro",
@@ -81,7 +92,7 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
     {
       "model": "gemini-3-flash-preview",
       "id": "custom:droidproxy:gemini-3-flash",
-      "index": 6,
+      "index": 7,
       "baseUrl": "http://localhost:8317",
       "apiKey": "dummy-not-used",
       "displayName": "DroidProxy: Gemini 3 Flash",
@@ -100,6 +111,7 @@ Use the standard Claude and Codex model aliases in the `model` field. Claude ent
 2. Set the desired effort:
    - Opus 4.7: `low`, `medium`, `high`, `xhigh`, or `max`
    - Sonnet 4.6: `low`, `medium`, `high`, or `max`
+   - GPT 5.2: `low`, `medium`, `high`, or `xhigh`
    - GPT 5.3 Codex: `low`, `medium`, `high`, or `xhigh`
    - GPT 5.4: `low`, `medium`, `high`, or `xhigh`
    - GPT 5.5: `low`, `medium`, `high`, or `xhigh`

--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -33,6 +33,10 @@ enum AppPreferences {
     static let defaultGpt53CodexFastMode = false
     static let defaultGpt54FastMode = false
     static let defaultGpt55FastMode = false
+    static let gpt52ReasoningEffortKey = "gpt52ReasoningEffort"
+    static let gpt52FastModeKey = "gpt52FastMode"
+    static let defaultGpt52ReasoningEffort = "high"
+    static let defaultGpt52FastMode = false
     static let defaultGemini31ProThinkingLevel = "high"
     static let defaultGemini3FlashThinkingLevel = "high"
     static let defaultK26ReasoningEnabled = true
@@ -138,6 +142,18 @@ enum AppPreferences {
             return defaultK26ReasoningEnabled
         }
         return defaults.bool(forKey: k26ReasoningEnabledKey)
+    }
+
+    static var gpt52ReasoningEffort: String {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: gpt52ReasoningEffortKey) != nil else {
+            return defaultGpt52ReasoningEffort
+        }
+        return defaults.string(forKey: gpt52ReasoningEffortKey) ?? defaultGpt52ReasoningEffort
+    }
+
+    static var gpt52FastMode: Bool {
+        UserDefaults.standard.bool(forKey: gpt52FastModeKey)
     }
 
     static var backgroundOpacity: Double {

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -133,6 +133,18 @@ enum DroidProxyModelCatalog {
             levels: claudeClassicLevels
         ),
         DroidProxyModelDefinition(
+            baseModel: "gpt-5.2",
+            idSlug: "gpt-5.2",
+            displayName: "GPT 5.2",
+            maxOutputTokens: 128000,
+            provider: "openai",
+            providerKey: "codex",
+            baseURL: "http://localhost:8317/v1",
+            kind: .codex,
+            levelLabel: "Reasoning",
+            levels: codexLevels
+        ),
+        DroidProxyModelDefinition(
             baseModel: "gpt-5.3-codex",
             idSlug: "gpt-5.3-codex",
             displayName: "GPT 5.3 Codex",

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -510,9 +510,11 @@ struct SettingsView: View {
     @AppStorage(AppPreferences.opus46ThinkingEffortKey) private var opus46ThinkingEffort = AppPreferences.defaultOpus46ThinkingEffort
     @AppStorage(AppPreferences.opus45ThinkingEffortKey) private var opus45ThinkingEffort = AppPreferences.defaultOpus45ThinkingEffort
     @AppStorage(AppPreferences.sonnet46ThinkingEffortKey) private var sonnet46ThinkingEffort = AppPreferences.defaultSonnet46ThinkingEffort
+    @AppStorage(AppPreferences.gpt52ReasoningEffortKey) private var gpt52ReasoningEffort = AppPreferences.defaultGpt52ReasoningEffort
     @AppStorage(AppPreferences.gpt53CodexReasoningEffortKey) private var gpt53CodexReasoningEffort = AppPreferences.defaultGpt53CodexReasoningEffort
     @AppStorage(AppPreferences.gpt54ReasoningEffortKey) private var gpt54ReasoningEffort = AppPreferences.defaultGpt54ReasoningEffort
     @AppStorage(AppPreferences.gpt55ReasoningEffortKey) private var gpt55ReasoningEffort = AppPreferences.defaultGpt55ReasoningEffort
+    @AppStorage(AppPreferences.gpt52FastModeKey) private var gpt52FastMode = AppPreferences.defaultGpt52FastMode
     @AppStorage(AppPreferences.gpt53CodexFastModeKey) private var gpt53CodexFastMode = AppPreferences.defaultGpt53CodexFastMode
     @AppStorage(AppPreferences.gpt54FastModeKey) private var gpt54FastMode = AppPreferences.defaultGpt54FastMode
     @AppStorage(AppPreferences.gpt55FastModeKey) private var gpt55FastMode = AppPreferences.defaultGpt55FastMode
@@ -737,7 +739,7 @@ struct SettingsView: View {
                                 .font(.caption)
                         }
                         .buttonStyle(.plain)
-                        .help("Installs three devil's advocate code reviewer droids (Opus 4.7, GPT 5.4, Gemini 3.1 Pro) and their slash commands into your Factory config. Use /challenge-opus, /challenge-gpt, or /challenge-gemini in any Droid session for a cross-model second opinion on your code.")
+                        .help("Installs three devil's advocate code reviewer droids (Opus 4.7, GPT 5.2, Gemini 3.1 Pro) and their slash commands into your Factory config. Use /challenge-opus, /challenge-gpt, or /challenge-gemini in any Droid session for a cross-model second opinion on your code.")
                         Spacer()
                         if challengerPluginInstalled {
                             HStack(spacing: 4) {
@@ -977,6 +979,11 @@ struct SettingsView: View {
                                 if factoryAdvancedModels {
                                     advancedFactoryModelsNotice("Codex")
                                     codexFastModeToggleRow(
+                                        "GPT 5.2",
+                                        isOn: $gpt52FastMode,
+                                        helpText: "Injects service_tier=priority for GPT 5.2 Responses API requests (Codex fast mode)"
+                                    )
+                                    codexFastModeToggleRow(
                                         "GPT 5.3 Codex",
                                         isOn: $gpt53CodexFastMode,
                                         helpText: "Injects service_tier=priority for GPT 5.3 Codex Responses API requests (Codex fast mode)"
@@ -992,6 +999,27 @@ struct SettingsView: View {
                                         helpText: "Injects service_tier=priority for GPT 5.5 Responses API requests (Codex fast mode)"
                                     )
                                 } else {
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        HStack {
+                                            Text("GPT 5.2 reasoning effort")
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+                                            Spacer()
+                                            Toggle("Fast mode", isOn: $gpt52FastMode)
+                                                .toggleStyle(.checkbox)
+                                                .font(.caption)
+                                                .help("Injects service_tier=priority for GPT 5.2 Responses API requests (Codex fast mode)")
+                                        }
+                                        Picker("", selection: $gpt52ReasoningEffort) {
+                                            ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
+                                                Text(option).tag(option)
+                                            }
+                                        }
+                                        .pickerStyle(.segmented)
+                                        .tint(codexEffortSelectionColor)
+                                        .labelsHidden()
+                                    }
+                                    .padding(.vertical, 2)
                                     VStack(alignment: .leading, spacing: 6) {
                                         HStack {
                                             Text("GPT 5.3 Codex reasoning effort")
@@ -1627,7 +1655,7 @@ struct SettingsView: View {
         ---
         name: challenger-gpt
         description: Devil's advocate code reviewer that challenges decisions, critiques patterns, and suggests better alternatives. Use when you want a tough second opinion on code, architecture, or design choices.
-        model: custom:droidproxy:gpt-5.5
+        model: custom:droidproxy:gpt-5.2
         tools: ["Read", "LS", "Grep", "Glob", "WebSearch", "FetchUrl"]
         ---
 
@@ -1759,7 +1787,7 @@ struct SettingsView: View {
         if factoryAdvancedModels {
             rendered = rendered
                 .replacingOccurrences(of: "model: custom:droidproxy:opus-4-7", with: "model: custom:droidproxy:opus-4-7-xhigh")
-                .replacingOccurrences(of: "model: custom:droidproxy:gpt-5.5", with: "model: custom:droidproxy:gpt-5.5-high")
+                .replacingOccurrences(of: "model: custom:droidproxy:gpt-5.2", with: "model: custom:droidproxy:gpt-5.2-high")
                 .replacingOccurrences(of: "model: custom:droidproxy:gemini-3.1-pro", with: "model: custom:droidproxy:gemini-3.1-pro-high")
         }
 

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -999,90 +999,26 @@ struct SettingsView: View {
                                         helpText: "Injects service_tier=priority for GPT 5.5 Responses API requests (Codex fast mode)"
                                     )
                                 } else {
-                                    VStack(alignment: .leading, spacing: 6) {
-                                        HStack {
-                                            Text("GPT 5.2 reasoning effort")
-                                                .font(.caption)
-                                                .foregroundColor(.secondary)
-                                            Spacer()
-                                            Toggle("Fast mode", isOn: $gpt52FastMode)
-                                                .toggleStyle(.checkbox)
-                                                .font(.caption)
-                                                .help("Injects service_tier=priority for GPT 5.2 Responses API requests (Codex fast mode)")
-                                        }
-                                        Picker("", selection: $gpt52ReasoningEffort) {
-                                            ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
-                                                Text(option).tag(option)
-                                            }
-                                        }
-                                        .pickerStyle(.segmented)
-                                        .tint(codexEffortSelectionColor)
-                                        .labelsHidden()
-                                    }
-                                    .padding(.vertical, 2)
-                                    VStack(alignment: .leading, spacing: 6) {
-                                        HStack {
-                                            Text("GPT 5.3 Codex reasoning effort")
-                                                .font(.caption)
-                                                .foregroundColor(.secondary)
-                                            Spacer()
-                                            Toggle("Fast mode", isOn: $gpt53CodexFastMode)
-                                                .toggleStyle(.checkbox)
-                                                .font(.caption)
-                                                .help("Injects service_tier=priority for GPT 5.3 Codex Responses API requests (Codex fast mode)")
-                                        }
-                                        Picker("", selection: $gpt53CodexReasoningEffort) {
-                                            ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
-                                                Text(option).tag(option)
-                                            }
-                                        }
-                                        .pickerStyle(.segmented)
-                                        .tint(codexEffortSelectionColor)
-                                        .labelsHidden()
-                                    }
-                                    .padding(.vertical, 2)
-                                    VStack(alignment: .leading, spacing: 6) {
-                                        HStack {
-                                            Text("GPT 5.4 reasoning effort")
-                                                .font(.caption)
-                                                .foregroundColor(.secondary)
-                                            Spacer()
-                                            Toggle("Fast mode", isOn: $gpt54FastMode)
-                                                .toggleStyle(.checkbox)
-                                                .font(.caption)
-                                                .help("Injects service_tier=priority for GPT 5.4 Responses API requests (Codex fast mode)")
-                                        }
-                                        Picker("", selection: $gpt54ReasoningEffort) {
-                                            ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
-                                                Text(option).tag(option)
-                                            }
-                                        }
-                                        .pickerStyle(.segmented)
-                                        .tint(codexEffortSelectionColor)
-                                        .labelsHidden()
-                                    }
-                                    .padding(.vertical, 2)
-                                    VStack(alignment: .leading, spacing: 6) {
-                                        HStack {
-                                            Text("GPT 5.5 reasoning effort")
-                                                .font(.caption)
-                                                .foregroundColor(.secondary)
-                                            Spacer()
-                                            Toggle("Fast mode", isOn: $gpt55FastMode)
-                                                .toggleStyle(.checkbox)
-                                                .font(.caption)
-                                                .help("Injects service_tier=priority for GPT 5.5 Responses API requests (Codex fast mode)")
-                                        }
-                                        Picker("", selection: $gpt55ReasoningEffort) {
-                                            ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
-                                                Text(option).tag(option)
-                                            }
-                                        }
-                                        .pickerStyle(.segmented)
-                                        .tint(codexEffortSelectionColor)
-                                        .labelsHidden()
-                                    }
-                                    .padding(.vertical, 2)
+                                    codexReasoningEffortRow(
+                                        "GPT 5.2",
+                                        effortSelection: $gpt52ReasoningEffort,
+                                        fastMode: $gpt52FastMode
+                                    )
+                                    codexReasoningEffortRow(
+                                        "GPT 5.3 Codex",
+                                        effortSelection: $gpt53CodexReasoningEffort,
+                                        fastMode: $gpt53CodexFastMode
+                                    )
+                                    codexReasoningEffortRow(
+                                        "GPT 5.4",
+                                        effortSelection: $gpt54ReasoningEffort,
+                                        fastMode: $gpt54FastMode
+                                    )
+                                    codexReasoningEffortRow(
+                                        "GPT 5.5",
+                                        effortSelection: $gpt55ReasoningEffort,
+                                        fastMode: $gpt55FastMode
+                                    )
                                 }
                             }
                         }
@@ -1309,6 +1245,35 @@ struct SettingsView: View {
                 .toggleStyle(.checkbox)
                 .font(.caption)
                 .help(helpText)
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private func codexReasoningEffortRow(
+        _ title: String,
+        effortSelection: Binding<String>,
+        fastMode: Binding<Bool>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("\(title) reasoning effort")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Spacer()
+                Toggle("Fast mode", isOn: fastMode)
+                    .toggleStyle(.checkbox)
+                    .font(.caption)
+                    .help("Injects service_tier=priority for \(title) Responses API requests (Codex fast mode)")
+            }
+            Picker("", selection: effortSelection) {
+                ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
+                    Text(option).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+            .tint(codexEffortSelectionColor)
+            .labelsHidden()
         }
         .padding(.vertical, 2)
     }

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -18,8 +18,9 @@ import Network
    `redact-thinking-2026-02-12`, otherwise Claude emits only signed empty thinking blocks.
  - Requests whose `model` is exactly `gpt-5.3-codex` receive `reasoning: {"effort":"..."}`
    from `AppPreferences.gpt53CodexReasoningEffort`
-- Requests whose `model` is exactly `gpt-5.4` or `gpt-5.5` receive `reasoning: {"effort":"..."}`
-  from `AppPreferences.gpt54ReasoningEffort` or `AppPreferences.gpt55ReasoningEffort`
+- Requests whose `model` is exactly `gpt-5.2`, `gpt-5.4`, or `gpt-5.5` receive
+  `reasoning: {"effort":"..."}` from `AppPreferences.gpt52ReasoningEffort`,
+  `AppPreferences.gpt54ReasoningEffort`, or `AppPreferences.gpt55ReasoningEffort`
 - Other models are forwarded unchanged
 - Requests whose `model` is exactly `kimi-k2.6` receive `reasoning: {"effort":"..."}`
   from `AppPreferences.k26ReasoningEffort`
@@ -520,6 +521,8 @@ class ThinkingProxy {
 
     private func codexReasoningEffort(for model: String) -> String? {
         switch model {
+        case "gpt-5.2":
+            return AppPreferences.gpt52ReasoningEffort
         case "gpt-5.3-codex":
             return AppPreferences.gpt53CodexReasoningEffort
         case "gpt-5.4":
@@ -1000,6 +1003,8 @@ class ThinkingProxy {
         }
 
         switch model {
+        case "gpt-5.2":
+            guard AppPreferences.gpt52FastMode else { return nil }
         case "gpt-5.4":
             guard AppPreferences.gpt54FastMode else { return nil }
         case "gpt-5.5":

--- a/website/src/components/ModelsSection.tsx
+++ b/website/src/components/ModelsSection.tsx
@@ -17,6 +17,14 @@ const models = [
   },
   {
     icon: '/assets/icon-codex.png',
+    name: 'GPT 5.2',
+    id: 'gpt-5.2',
+    levels: ['low', 'medium', 'high', 'xhigh', 'fast'],
+    max: '128,000',
+    provider: 'OpenAI',
+  },
+  {
+    icon: '/assets/icon-codex.png',
     name: 'GPT 5.3 Codex',
     id: 'gpt-5.3-codex',
     levels: ['low', 'medium', 'high', 'xhigh', 'fast'],


### PR DESCRIPTION
## Summary

This PR adds GPT 5.2 as a first-class DroidProxy model and points the GPT challenger droid at it, based on Factory's published code-review benchmark.

**What's new for users**

- **GPT 5.2 in the model picker.** Sign in to Codex and you'll get a new `DroidProxy: GPT 5.2` entry alongside 5.3/5.4/5.5 after clicking Apply Factory Models, with the same per-model reasoning effort dial (`low` / `medium` / `high` / `xhigh`, default `high`) and Fast Mode toggle (`service_tier=priority` on Responses API requests) as the existing GPT entries.
- **`/challenge-gpt` now uses GPT 5.2.** The devil's-advocate code reviewer droid you get from Apply Challenger Plugin (and the project copy in `.factory/droids/`) now runs on `custom:droidproxy:gpt-5.2` instead of the previous mix of 5.4/5.5. Per Factory's [code review benchmark](https://factory.ai/news/code-review-benchmark):

  > A note on GPT-5.4 and GPT-5.5: both underperform GPT-5.2, but for opposite reasons. GPT-5.4 is too conservative -- it comments sparingly (2.5/PR vs the 3.2 golden average) with decent precision (56.8%) but misses too many real bugs (42.4% recall). GPT-5.5 swings the other way: it comments at the right rate (3.5/PR) but nearly half are false positives (47.5% precision). In our experiments, GPT-5.4 needs explicit severity filters and strict constraints to stay focused, while GPT-5.5 needs tighter validation to filter out noise. Models like GPT-5.2 are more naturally calibrated with general-purpose prompts, which is why they outperform both in a standardized benchmark.
  >
  > Top-tier quality at half the cost of Opus 4.6.

- **Docs caught up.** README, SETUP.md, the Models section on the website, and CHANGELOG all mention GPT 5.2 and the new challenger model.

**Behind the scenes**

- Added a `gpt-5.2` definition to `DroidProxyModelCatalog` (codex levels, 128k max output, OpenAI provider) so it flows through Factory custom-models provisioning the same way the other Codex models do.
- New `gpt52ReasoningEffortKey` / `gpt52FastModeKey` + defaults in `AppPreferences`, surfaced via `@AppStorage` in `SettingsView` for both the simple and advanced Codex panels.
- `ThinkingProxy` now injects `reasoning.effort` for `gpt-5.2` from the new pref and honors fast-mode on `/v1/responses` / `/api/v1/responses`.
- Fixed a small pre-existing mismatch in the Challenger Plugin help text (it said "GPT 5.4" while the installed droid was GPT 5.5); both are now unified on GPT 5.2.
- Deduplicated the simple-mode Codex panel — four near-identical 22-line `VStack` blocks for GPT 5.2 / 5.3 Codex / 5.4 / 5.5 collapsed into a single `codexReasoningEffortRow(_:effortSelection:fastMode:)` `@ViewBuilder` helper (net `-84 / +49` in `SettingsView.swift`).

## Testing

- `cd src && swift build` succeeds (only pre-existing warnings).
- Manual smoke: open Settings → Codex section shows the new GPT 5.2 reasoning effort row + Fast mode checkbox; Apply Factory Models adds `custom:droidproxy:gpt-5.2` to `~/.factory/settings.json`; Apply Challenger Plugin writes `model: custom:droidproxy:gpt-5.2` into `~/.factory/droids/challenger-gpt.md`.
