### PR TITLE
docs(AGENTS.md): refresh to match current main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ graphify-out/cache/
 
 # Junie metadata
 .junie/
+
+# Vix tool data
+.vix/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,7 @@ src/.build/artifacts/sparkle/Sparkle/bin/sign_update DroidProxy-arm64.zip
 
 ## Source Of Truth
 
-The compiled app code is under `src/`. Treat `src/Sources/**`, `src/Info.plist`, and `create-app-bundle.sh` as source of truth.
-
-There is also a top-level `resources/` tree containing mirrored Swift files and assets. It is not the SwiftPM target used by `src/Package.swift`, so do not assume edits there affect the app unless the task is explicitly about that directory.
+The compiled app code is under `src/`. Treat `src/Sources/**`, `src/Info.plist`, and `create-app-bundle.sh` as source of truth. There is no longer a mirrored top-level `resources/` tree — older AGENTS notes about it are stale.
 
 ## Architecture
 
@@ -56,28 +54,35 @@ Typical request flow:
 
 What it does today:
 
-- Inspects `POST` JSON requests for supported Claude, Codex GPT, and Gemini models
-- Injects Claude adaptive thinking for models whose name contains `opus-4-7` or `sonnet-4-6`
-- Injects `"thinking":{"type":"adaptive"}` and forces `"stream":true` for Claude
-- Injects `"output_config":{"effort":"..."}`
-- Reads effort from `AppPreferences.opus47ThinkingEffort` or `AppPreferences.sonnet46ThinkingEffort`
-- Injects Codex reasoning for exact models `gpt-5.3-codex`, `gpt-5.4`, and `gpt-5.5`
-- Injects `"reasoning":{"effort":"..."}`
-- Reads effort from `AppPreferences.gpt53CodexReasoningEffort`, `AppPreferences.gpt54ReasoningEffort`, or `AppPreferences.gpt55ReasoningEffort`
-- Injects Gemini thinking levels for `gemini-3.1-pro-preview` and `gemini-3-flash-preview`
-- Injects Kimi reasoning for `kimi-k2.6`
-- Rewrites the model name to append a suffix (e.g. `gemini-3.1-pro-preview(high)`) which CLIProxyAPIPlus parses via its `ParseSuffix` logic
-- Reads level from `AppPreferences.gemini31ProThinkingLevel` or `AppPreferences.gemini3FlashThinkingLevel`
-- Reads Kimi effort from `AppPreferences.k26ReasoningEffort`
-- Optionally injects `"service_tier":"priority"` for `gpt-5.4` or `gpt-5.5` on Responses API paths (`/v1/responses`, `/api/v1/responses`) when `AppPreferences.gpt54FastMode` or `AppPreferences.gpt55FastMode` is enabled and the client did not already set `service_tier`
-- Preserves JSON key order by editing the raw JSON string instead of re-serializing
-- **Max Budget Mode**: When `AppPreferences.claudeMaxBudgetMode` is enabled, forces streaming and applies a Sonnet-4.6-only override: classic extended thinking with `budget_tokens=63999` / `max_tokens=64000` / `effort=max`. Opus 4.7 is unaffected and continues to receive `thinking.type=adaptive` with `output_config.effort` from `AppPreferences.opus47ThinkingEffort`.
+- Inspects `POST` JSON requests for supported Claude, Codex GPT, Gemini, and Kimi models
+- **Claude adaptive thinking** for models whose name contains `opus-4-7`, `opus-4-6`, or `sonnet-4-6`:
+  - Injects `"thinking":{"type":"adaptive"}` (Opus 4.7 gets `{"type":"adaptive","display":"summarized"}`)
+  - Injects `"output_config":{"effort":"..."}`
+  - Forces `"stream":true`
+  - Reads effort from `AppPreferences.opus47ThinkingEffort`, `AppPreferences.opus46ThinkingEffort`, or `AppPreferences.sonnet46ThinkingEffort`
+- **Claude classic thinking** for models whose name contains `opus-4-5` (which does not support adaptive thinking):
+  - Injects `"thinking":{"type":"enabled","budget_tokens":N}` plus a matching `"max_tokens"`, mapped from `AppPreferences.opus45ThinkingEffort` (low/medium/high/max → fixed budget/max-token pairs, see `opus45ClassicBudget`)
+  - Forces `"stream":true`
+- **Anthropic-Beta rewriting**: When a Claude request has `thinking.type` of `enabled`/`adaptive`/`auto`, the proxy strips `redact-thinking-2026-02-12` from the `Anthropic-Beta` header and appends the visible-thinking beta list (interleaved-thinking, prompt-caching-scope, fast-mode, etc.). Without this, Claude emits only signed empty thinking blocks.
+- **Codex reasoning** for exact models `gpt-5.2`, `gpt-5.3-codex`, `gpt-5.4`, and `gpt-5.5`:
+  - Injects `"reasoning":{"effort":"..."}`
+  - Reads effort from `AppPreferences.gpt52ReasoningEffort`, `AppPreferences.gpt53CodexReasoningEffort`, `AppPreferences.gpt54ReasoningEffort`, or `AppPreferences.gpt55ReasoningEffort`
+- **Gemini thinking levels** for `gemini-3.1-pro-preview` and `gemini-3-flash-preview`:
+  - Rewrites the model name to append a suffix (e.g. `gemini-3.1-pro-preview(high)`) which CLIProxyAPIPlus parses via its `ParseSuffix` logic
+  - Reads level from `AppPreferences.gemini31ProThinkingLevel` or `AppPreferences.gemini3FlashThinkingLevel`
+  - Also rewrites `/v1/responses` (and `/api/v1/responses`) to `/v1/chat/completions` for Gemini models since CLIProxyAPIPlus does not support Gemini via the Responses API
+- **Kimi reasoning** for `kimi-k2.6`:
+  - Injects `"reasoning":{"effort":"high"}` when `AppPreferences.k26ReasoningEnabled` is true; passes through unchanged otherwise (k2.6 only has a boolean toggle, not an effort picker)
+- **Service tier (fast mode)** for Responses API paths (`/v1/responses`, `/api/v1/responses`): injects `"service_tier":"priority"` for `gpt-5.2`, `gpt-5.4`, or `gpt-5.5` when `AppPreferences.gpt52FastMode`, `AppPreferences.gpt54FastMode`, or `AppPreferences.gpt55FastMode` is enabled and the client did not already set `service_tier`
+- **Factory advanced variants**: When a request's model matches a `DroidProxyModelCatalog.advancedVariant` (e.g. `claude-opus-4-7(high)`), the proxy strips the level suffix, rewrites the JSON `model`, and routes through the matching Claude/Codex/Gemini/Kimi injection path with the variant's level overriding the AppPreferences default
+- Preserves JSON key order by editing the raw JSON string instead of re-serializing (critical for Anthropic's prompt cache)
+- **Max Budget Mode**: When `AppPreferences.claudeMaxBudgetMode` is enabled, the Sonnet 4.6 / Opus 4.6 adaptive path is replaced with classic extended thinking — `"thinking":{"type":"enabled","budget_tokens":63999}`, `"max_tokens":64000`, `"output_config":{"effort":"max"}`, and forced streaming. Opus 4.7 is unaffected and continues to receive `thinking.type=adaptive` with `output_config.effort` from `AppPreferences.opus47ThinkingEffort`.
 
 What it does not do anymore:
 
-- It does not strip or normalize model suffixes
-- It does not send `thinking.budget_tokens` to Opus 4.7 (rejected with 400)
-- It does not add `anthropic-beta` interleaved-thinking headers (adaptive thinking enables interleaving automatically)
+- It does not strip or normalize model suffixes for unsupported models
+- It does not send `thinking.budget_tokens` to Opus 4.6 or 4.7 (those use adaptive thinking only — budget_tokens is rejected). Opus 4.5 and the Max Budget override deliberately *do* use `budget_tokens`.
+- It does not add `anthropic-beta` interleaved-thinking headers manually for adaptive models (adaptive thinking enables interleaving automatically; the Anthropic-Beta rewrite above is about removing `redact-thinking-2026-02-12`)
 - It does not implement the old `-thinking-N` / suffix-based branching documented in stale docs
 
 ### Amp routing
@@ -91,7 +96,7 @@ What it does not do anymore:
 
 ## Auth And Providers
 
-The current app/UI exposes three provider types:
+The current app/UI exposes four provider types:
 
 - `claude`
 - `codex`
@@ -120,37 +125,42 @@ Behavior to know:
 
 | File | Role |
 |---|---|
+| `src/Sources/main.swift` | NSApplication entry point that instantiates `AppDelegate` and calls `NSApplicationMain`. |
 | `src/Sources/AppDelegate.swift` | App lifecycle, menu bar UI, settings window, notifications, Sparkle updater, auth-directory watcher, startup ordering for the two local servers. |
 | `src/Sources/ServerManager.swift` | Starts/stops bundled `cli-proxy-api-plus`, captures logs, merges config, handles provider enable/disable, runs Claude/Codex/Gemini login commands, and kills orphaned backend processes. |
-| `src/Sources/ThinkingProxy.swift` | Raw TCP HTTP proxy for thinking injection plus Amp request/response rewriting. |
-| `src/Sources/SettingsView.swift` | SwiftUI settings UI for server status, launch-at-login, provider toggles, auth flows, and per-model effort pickers. |
+| `src/Sources/ThinkingProxy.swift` | Raw TCP HTTP proxy for thinking/reasoning injection, Anthropic-Beta header rewriting, Gemini path rewriting, factory-advanced variant routing, and Amp request/response rewriting. |
+| `src/Sources/DroidProxyModelCatalog.swift` | Authoritative catalog of DroidProxy-exposed models (base + advanced variants per reasoning/thinking level). Powers Settings entries when `factoryAdvancedModels` is on and `ThinkingProxy.advancedVariant` lookups. |
+| `src/Sources/SettingsView.swift` | SwiftUI settings UI for server status, launch-at-login, provider toggles, auth flows, per-model effort/level pickers, Kimi reasoning toggle, Max Budget Mode, factory-advanced-models toggle, OLED theme, background opacity, and remote-access settings. |
 | `src/Sources/AuthStatus.swift` | `AuthManager`, account parsing, expiry detection, file deletion, and per-account disabled-state updates. |
-| `src/Sources/AppPreferences.swift` | UserDefaults-backed effort preferences for Opus 4.7, Sonnet 4.6, GPT 5.3 Codex, GPT 5.4, Gemini 3.1 Pro, Gemini 3 Flash, and Kimi K2.6, plus fast mode toggles and the usage probe controls (`showUsageInMenuBar`, `usageAutoRefreshSeconds`). |
+| `src/Sources/AppPreferences.swift` | UserDefaults-backed preferences: effort/level for Opus 4.7/4.6/4.5, Sonnet 4.6, GPT 5.2/5.3-codex/5.4/5.5, Gemini 3.1 Pro, Gemini 3 Flash; Kimi K2.6 enabled toggle; fast-mode toggles for GPT 5.2/5.3-codex/5.4/5.5; `claudeMaxBudgetMode`, `allowRemote`, `secretKey`, `oledTheme`, `factoryAdvancedModels`, `backgroundOpacity`; and the usage probe controls (`showUsageInMenuBar`, `usageAutoRefreshSeconds`). |
 | `src/Sources/ClaudeUsageProbe.swift` | Hits `https://api.anthropic.com/api/oauth/usage` with the access token from `~/.cli-proxy-api/claude-*.json`. Handles OAuth refresh against `platform.claude.com/v1/oauth/token` (atomic write back to the auth file) and decodes the flat-keyed response shape (`five_hour`, `seven_day_*`). |
 | `src/Sources/CodexUsageProbe.swift` | Spawns `codex -s read-only -a untrusted app-server` as a child process and issues line-delimited JSON-RPC (`initialize` + `account/rateLimits/read`) to read Codex/ChatGPT rate limit windows. Requires the `codex` CLI to be installed and logged in. |
 | `src/Sources/UsageStore.swift` | `@MainActor` singleton that fan-outs to both probes in parallel, debounces overlapping refreshes (cancels in-flight task before starting a new one), and schedules a repeating timer based on `AppPreferences.usageAutoRefreshSeconds` (skips scheduling when set to 0/Manual). Posts `usageUpdated` notifications for UI consumers. |
 | `src/Sources/UsageModels.swift` | `UsageWindowKind`, `UsageWindow`, and `ProviderUsageSnapshot` data types shared by the probes and `AppDelegate`. Probes leave `limit` / `used` at `0` since the upstream APIs return only `percentUsed`. |
+| `src/Sources/NotificationNames.swift` | Shared `Notification.Name` constants (`serverStatusChanged`, `authDirectoryChanged`, `usageUpdated`). |
+| `src/Sources/IconCatalog.swift` | Caches `NSImage` lookups from the bundle's resource path so menu-bar / settings icons aren't re-decoded per access. |
+| `src/Sources/LogoView.swift` | Inline-SVG `LogoView` used in the settings UI. |
+| `src/Sources/TunnelManager.swift` | Stubbed tunnel/remote-access scaffolding; currently not wired into the app flow despite the matching `allowRemote`/`secretKey` preferences. |
 | `src/Sources/Resources/config.yaml` | Bundled CLIProxyAPIPlus config (`port: 8318`, localhost binding, Amp upstream settings, auth dir). |
 | `src/Info.plist` | Bundle metadata. Current source-of-truth values include app name `DroidProxy`, bundle ID `com.droidproxy.app`, and Sparkle feed URL on `anand-92/droidproxy`. |
 
 ## Conventions
 
 - Use `NSLog`, not `print` or `os_log`
-- Prefer updating the app under `src/`, not the mirrored top-level `resources/` directory
+- Edits land in `src/Sources/**`; there is no longer a parallel top-level `resources/` mirror
 - Treat `DroidProxy.app`, `CLIProxyMenuBar`, and `com.droidproxy.app` as the active app identity
 - `CLIProxyAPIPlus` is bundled as `src/Sources/Resources/cli-proxy-api-plus`
-- `ThinkingProxy` uses surgical string insertion for JSON edits to preserve cache-sensitive key ordering
+- `ThinkingProxy` uses surgical string insertion for JSON edits to preserve cache-sensitive key ordering (do not switch to `JSONSerialization.data` round-trips)
 - Local backend traffic is intended to stay on localhost only (`127.0.0.1:8318`)
-- `TunnelManager.swift` exists in `src/Sources/` but is currently not wired into the app flow
 
 ## Release Notes For Agents
 
-The repo still contains stale VibeProxy-era references outside the active runtime path. Before changing release automation, double-check names and URLs against current files.
+Release automation lives in `.github/workflows/release.yml` (no `Makefile` or `scripts/create-release.sh` in this repo). The workflow has already been migrated off the old `VibeProxy` / `automazeio/vibeproxy` identity.
 
-Known drift includes some combinations of:
+Legacy `VibeProxy` references still live in:
 
-- `Makefile`
-- `scripts/create-release.sh`
-- `.github/workflows/release.yml`
+- `appcast-x86_64.xml` (historical enclosure URLs)
+- `CHANGELOG.md` (release history)
+- `context/OG-vibeproxy-we-forked/` (full upstream fork snapshot, reference only)
 
-Those files still reference old names like `VibeProxy.app`, `automazeio/vibeproxy`, and legacy appcast URLs in places. If a task touches release tooling, audit it carefully instead of trusting the existing wording.
+Those are intentional history. If a task touches release tooling, audit the current workflow and `create-app-bundle.sh` rather than copying from those legacy files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,8 @@ What it does today:
   - Reads level from `AppPreferences.gemini31ProThinkingLevel` or `AppPreferences.gemini3FlashThinkingLevel`
   - Also rewrites `/v1/responses` (and `/api/v1/responses`) to `/v1/chat/completions` for Gemini models since CLIProxyAPIPlus does not support Gemini via the Responses API
 - **Kimi reasoning** for `kimi-k2.6`:
-  - Injects `"reasoning":{"effort":"high"}` when `AppPreferences.k26ReasoningEnabled` is true; passes through unchanged otherwise (k2.6 only has a boolean toggle, not an effort picker)
-- **Service tier (fast mode)** for Responses API paths (`/v1/responses`, `/api/v1/responses`): injects `"service_tier":"priority"` for `gpt-5.2`, `gpt-5.4`, or `gpt-5.5` when `AppPreferences.gpt52FastMode`, `AppPreferences.gpt54FastMode`, or `AppPreferences.gpt55FastMode` is enabled and the client did not already set `service_tier`
+  - Injects a top-level `"reasoning_effort":"high"` when `AppPreferences.k26ReasoningEnabled` is true; passes through unchanged otherwise (k2.6 only has a boolean toggle, not an effort picker)
+- **Service tier (fast mode)** for Responses API paths (`/v1/responses`, `/api/v1/responses`): injects `"service_tier":"priority"` for `gpt-5.2`, `gpt-5.3-codex`, `gpt-5.4`, or `gpt-5.5` when `AppPreferences.gpt52FastMode`, `AppPreferences.gpt53CodexFastMode`, `AppPreferences.gpt54FastMode`, or `AppPreferences.gpt55FastMode` is enabled and the client did not already set `service_tier`
 - **Factory advanced variants**: When a request's model matches a `DroidProxyModelCatalog.advancedVariant` (e.g. `claude-opus-4-7(high)`), the proxy strips the level suffix, rewrites the JSON `model`, and routes through the matching Claude/Codex/Gemini/Kimi injection path with the variant's level overriding the AppPreferences default
 - Preserves JSON key order by editing the raw JSON string instead of re-serializing (critical for Anthropic's prompt cache)
 - **Max Budget Mode**: When `AppPreferences.claudeMaxBudgetMode` is enabled, the Sonnet 4.6 / Opus 4.6 adaptive path is replaced with classic extended thinking — `"thinking":{"type":"enabled","budget_tokens":63999}`, `"max_tokens":64000`, `"output_config":{"effort":"max"}`, and forced streaming. Opus 4.7 is unaffected and continues to receive `thinking.type=adaptive` with `output_config.effort` from `AppPreferences.opus47ThinkingEffort`.
@@ -147,7 +147,7 @@ Behavior to know:
 ## Conventions
 
 - Use `NSLog`, not `print` or `os_log`
-- Edits land in `src/Sources/**`; there is no longer a parallel top-level `resources/` mirror
+- Source-of-truth edits land under `src/` (especially `src/Sources/**`, `src/Sources/Resources/`, `src/Info.plist`) and `create-app-bundle.sh` at the repo root; there is no longer a parallel top-level `resources/` mirror
 - Treat `DroidProxy.app`, `CLIProxyMenuBar`, and `com.droidproxy.app` as the active app identity
 - `CLIProxyAPIPlus` is bundled as `src/Sources/Resources/cli-proxy-api-plus`
 - `ThinkingProxy` uses surgical string insertion for JSON edits to preserve cache-sensitive key ordering (do not switch to `JSONSerialization.data` round-trips)


### PR DESCRIPTION
Updates `AGENTS.md` to reflect the actual state of the repo. Verified against `main` at `50df8fc`.

### What changed

**Removed stale references**
- Top-level `resources/` mirror tree (no longer exists)
- `Makefile` and `scripts/create-release.sh` (no longer exist)
- VibeProxy references in `.github/workflows/release.yml` (already migrated)

**Expanded ThinkingProxy section**
- Opus 4.7 now documented with `display:"summarized"`
- Added Opus 4.6 adaptive thinking + `opus46ThinkingEffort`
- Added Opus 4.5 classic enabled thinking with `budget_tokens`/`max_tokens` from `opus45ThinkingEffort`
- Added `gpt-5.2` reasoning + fast mode
- Added Anthropic-Beta header rewriting (strips `redact-thinking-2026-02-12`, appends visible-thinking betas)
- Added Gemini `/v1/responses` → `/v1/chat/completions` rewrite
- Added factory-advanced variant routing via `DroidProxyModelCatalog.advancedVariant`

**Corrections**
- Kimi K2.6 uses `k26ReasoningEnabled` (Bool → `"high"`), not the non-existent `k26ReasoningEffort`
- Max Budget Mode now correctly noted as applying to both `sonnet-4-6` and `opus-4-6`
- 'Does not send `budget_tokens`' caveat clarified: Opus 4.5 and Max Budget Mode deliberately do

**AppPreferences row** refreshed with full current key set (opus46/45 efforts, gpt-5.2, k26ReasoningEnabled, claudeMaxBudgetMode, allowRemote, secretKey, oledTheme, factoryAdvancedModels, backgroundOpacity)

**Key Files table** now includes `main.swift`, `DroidProxyModelCatalog.swift`, `NotificationNames.swift`, `IconCatalog.swift`, `LogoView.swift`, and `TunnelManager.swift`

**Release Notes section** rewritten to point at `release.yml` and `create-app-bundle.sh` and to call out where legitimate VibeProxy history still lives (`appcast-x86_64.xml`, `CHANGELOG.md`, `context/OG-vibeproxy-we-forked/`).

Docs only, no code changes.