### PR TITLE
Update Gemini 3 Flash to 3.5 Flash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,9 @@ What it does today:
 - **Codex reasoning** for exact models `gpt-5.2`, `gpt-5.3-codex`, `gpt-5.4`, and `gpt-5.5`:
   - Injects `"reasoning":{"effort":"..."}`
   - Reads effort from `AppPreferences.gpt52ReasoningEffort`, `AppPreferences.gpt53CodexReasoningEffort`, `AppPreferences.gpt54ReasoningEffort`, or `AppPreferences.gpt55ReasoningEffort`
-- **Gemini thinking levels** for `gemini-3.1-pro-preview` and `gemini-3-flash-preview`:
+- **Gemini thinking levels** for `gemini-3.1-pro-preview` and `gemini-3.5-flash-preview`:
   - Rewrites the model name to append a suffix (e.g. `gemini-3.1-pro-preview(high)`) which CLIProxyAPIPlus parses via its `ParseSuffix` logic
-  - Reads level from `AppPreferences.gemini31ProThinkingLevel` or `AppPreferences.gemini3FlashThinkingLevel`
+  - Reads level from `AppPreferences.gemini31ProThinkingLevel` or `AppPreferences.gemini35FlashThinkingLevel`
   - Also rewrites `/v1/responses` (and `/api/v1/responses`) to `/v1/chat/completions` for Gemini models since CLIProxyAPIPlus does not support Gemini via the Responses API
 - **Kimi reasoning** for `kimi-k2.6`:
   - Injects a top-level `"reasoning_effort":"high"` when `AppPreferences.k26ReasoningEnabled` is true; passes through unchanged otherwise (k2.6 only has a boolean toggle, not an effort picker)
@@ -132,7 +132,7 @@ Behavior to know:
 | `src/Sources/DroidProxyModelCatalog.swift` | Authoritative catalog of DroidProxy-exposed models (base + advanced variants per reasoning/thinking level). Powers Settings entries when `factoryAdvancedModels` is on and `ThinkingProxy.advancedVariant` lookups. |
 | `src/Sources/SettingsView.swift` | SwiftUI settings UI for server status, launch-at-login, provider toggles, auth flows, per-model effort/level pickers, Kimi reasoning toggle, Max Budget Mode, factory-advanced-models toggle, OLED theme, background opacity, and remote-access settings. |
 | `src/Sources/AuthStatus.swift` | `AuthManager`, account parsing, expiry detection, file deletion, and per-account disabled-state updates. |
-| `src/Sources/AppPreferences.swift` | UserDefaults-backed preferences: effort/level for Opus 4.7/4.6/4.5, Sonnet 4.6, GPT 5.2/5.3-codex/5.4/5.5, Gemini 3.1 Pro, Gemini 3 Flash; Kimi K2.6 enabled toggle; fast-mode toggles for GPT 5.2/5.3-codex/5.4/5.5; `claudeMaxBudgetMode`, `allowRemote`, `secretKey`, `oledTheme`, `factoryAdvancedModels`, `backgroundOpacity`; and the usage probe controls (`showUsageInMenuBar`, `usageAutoRefreshSeconds`). |
+| `src/Sources/AppPreferences.swift` | UserDefaults-backed preferences: effort/level for Opus 4.7/4.6/4.5, Sonnet 4.6, GPT 5.2/5.3-codex/5.4/5.5, Gemini 3.1 Pro, Gemini 3.5 Flash; Kimi K2.6 enabled toggle; fast-mode toggles for GPT 5.2/5.3-codex/5.4/5.5; `claudeMaxBudgetMode`, `allowRemote`, `secretKey`, `oledTheme`, `factoryAdvancedModels`, `backgroundOpacity`; and the usage probe controls (`showUsageInMenuBar`, `usageAutoRefreshSeconds`). |
 | `src/Sources/ClaudeUsageProbe.swift` | Hits `https://api.anthropic.com/api/oauth/usage` with the access token from `~/.cli-proxy-api/claude-*.json`. Handles OAuth refresh against `platform.claude.com/v1/oauth/token` (atomic write back to the auth file) and decodes the flat-keyed response shape (`five_hour`, `seven_day_*`). |
 | `src/Sources/CodexUsageProbe.swift` | Spawns `codex -s read-only -a untrusted app-server` as a child process and issues line-delimited JSON-RPC (`initialize` + `account/rateLimits/read`) to read Codex/ChatGPT rate limit windows. Requires the `codex` CLI to be installed and logged in. |
 | `src/Sources/UsageStore.swift` | `@MainActor` singleton that fan-outs to both probes in parallel, debounces overlapping refreshes (cancels in-flight task before starting a new one), and schedules a repeating timer based on `AppPreferences.usageAutoRefreshSeconds` (skips scheduling when set to 0/Manual). Posts `usageUpdated` notifications for UI consumers. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ What it does today:
 - **Codex reasoning** for exact models `gpt-5.2`, `gpt-5.3-codex`, `gpt-5.4`, and `gpt-5.5`:
   - Injects `"reasoning":{"effort":"..."}`
   - Reads effort from `AppPreferences.gpt52ReasoningEffort`, `AppPreferences.gpt53CodexReasoningEffort`, `AppPreferences.gpt54ReasoningEffort`, or `AppPreferences.gpt55ReasoningEffort`
-- **Gemini thinking levels** for `gemini-3.1-pro-preview` and `gemini-3.5-flash-preview`:
+- **Gemini thinking levels** for `gemini-3.1-pro-preview` and `gemini-3.5-flash`:
   - Rewrites the model name to append a suffix (e.g. `gemini-3.1-pro-preview(high)`) which CLIProxyAPIPlus parses via its `ParseSuffix` logic
   - Reads level from `AppPreferences.gemini31ProThinkingLevel` or `AppPreferences.gemini35FlashThinkingLevel`
   - Also rewrites `/v1/responses` (and `/api/v1/responses`) to `/v1/chat/completions` for Gemini models since CLIProxyAPIPlus does not support Gemini via the Responses API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 - **Gemini provider support** -- OAuth login, credential monitoring, provider enable/disable, and service icon in Settings UI
-- **Gemini thinking level controls** -- Per-model thinking level pickers for Gemini 3.1 Pro (`low` / `medium` / `high`) and Gemini 3 Flash (`minimal` / `low` / `medium` / `high`)
-- **Gemini Factory custom models** -- `gemini-3.1-pro-preview` and `gemini-3-flash-preview` added to one-click Factory model provisioning
+- **Gemini thinking level controls** -- Per-model thinking level pickers for Gemini 3.1 Pro (`low` / `medium` / `high`) and Gemini 3.5 Flash (`minimal` / `low` / `medium` / `high`)
+- **Gemini Factory custom models** -- `gemini-3.1-pro-preview` and `gemini-3.5-flash-preview` added to one-click Factory model provisioning
 
 ## [1.8.121] - 2026-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - **Gemini provider support** -- OAuth login, credential monitoring, provider enable/disable, and service icon in Settings UI
 - **Gemini thinking level controls** -- Per-model thinking level pickers for Gemini 3.1 Pro (`low` / `medium` / `high`) and Gemini 3.5 Flash (`minimal` / `low` / `medium` / `high`)
-- **Gemini Factory custom models** -- `gemini-3.1-pro-preview` and `gemini-3.5-flash-preview` added to one-click Factory model provisioning
+- **Gemini Factory custom models** -- `gemini-3.1-pro-preview` and `gemini-3.5-flash` added to one-click Factory model provisioning
 
 ## [1.8.121] - 2026-04-02
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All releases are code-signed and notarized by Apple. Existing installs auto-upda
 ## Features
 
 - **One-click OAuth auth** -- Claude Code, Codex, Gemini, and Kimi login from the menu bar, credential monitoring, auto-refresh
-- **Per-model reasoning/effort controls** -- Configure Opus 4.7, Sonnet 4.6, GPT 5.2, GPT 5.3 Codex, GPT 5.4, GPT 5.5, Gemini 3.1 Pro, Gemini 3 Flash, and Kimi K2.6 directly from the Settings window. Also supports `fast` mode for gpt models.
+- **Per-model reasoning/effort controls** -- Configure Opus 4.7, Sonnet 4.6, GPT 5.2, GPT 5.3 Codex, GPT 5.4, GPT 5.5, Gemini 3.1 Pro, Gemini 3.5 Flash, and Kimi K2.6 directly from the Settings window. Also supports `fast` mode for gpt models.
 - **Max Budget Mode** -- Nuclear launch button that forces maximum reasoning on Opud/Sonnet 4.6 requests: classic extended thinking with `budget_tokens: 63999`, `max_tokens: 64000`, and `effort: max`. Opus 4.7 does not need this override. Full thinking power for Sonnet, your quota's problem.
 - **Usage tracking** -- Live Claude and Codex rate limit windows (5-hour + weekly) in the menu bar dropdown. Auto-refreshes every 5 minutes (configurable) and on Mac wake. Codex tracking requires the `codex` CLI to be installed and logged in (`codex login`).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -96,7 +96,7 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
       "baseUrl": "http://localhost:8317",
       "apiKey": "dummy-not-used",
       "displayName": "DroidProxy: Gemini 3.5 Flash",
-      "maxOutputTokens": 65536,
+      "maxOutputTokens": 65535,
       "noImageSupport": false,
       "provider": "google"
     }

--- a/SETUP.md
+++ b/SETUP.md
@@ -90,12 +90,12 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
       "provider": "google"
     },
     {
-      "model": "gemini-3-flash-preview",
-      "id": "custom:droidproxy:gemini-3-flash",
+      "model": "gemini-3.5-flash-preview",
+      "id": "custom:droidproxy:gemini-3.5-flash",
       "index": 7,
       "baseUrl": "http://localhost:8317",
       "apiKey": "dummy-not-used",
-      "displayName": "DroidProxy: Gemini 3 Flash",
+      "displayName": "DroidProxy: Gemini 3.5 Flash",
       "maxOutputTokens": 65536,
       "noImageSupport": false,
       "provider": "google"
@@ -116,7 +116,7 @@ Use the standard Claude and Codex model aliases in the `model` field. Claude ent
    - GPT 5.4: `low`, `medium`, `high`, or `xhigh`
    - GPT 5.5: `low`, `medium`, `high`, or `xhigh`
    - Gemini 3.1 Pro: `low`, `medium`, or `high`
-   - Gemini 3 Flash: `minimal`, `low`, `medium`, or `high`
+   - Gemini 3.5 Flash: `minimal`, `low`, `medium`, or `high`
 
 ## 4. Enable Thinking Output
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -90,7 +90,7 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
       "provider": "google"
     },
     {
-      "model": "gemini-3.5-flash-preview",
+      "model": "gemini-3.5-flash",
       "id": "custom:droidproxy:gemini-3.5-flash",
       "index": 7,
       "baseUrl": "http://localhost:8317",

--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -12,7 +12,7 @@ enum AppPreferences {
     static let gpt54FastModeKey = "gpt54FastMode"
     static let gpt55FastModeKey = "gpt55FastMode"
     static let gemini31ProThinkingLevelKey = "gemini31ProThinkingLevel"
-    static let gemini3FlashThinkingLevelKey = "gemini3FlashThinkingLevel"
+    static let gemini35FlashThinkingLevelKey = "gemini35FlashThinkingLevel"
     static let k26ReasoningEnabledKey = "k26ReasoningEnabled"
     static let claudeMaxBudgetModeKey = "claudeMaxBudgetMode"
     static let allowRemoteKey = "allowRemote"
@@ -38,7 +38,7 @@ enum AppPreferences {
     static let defaultGpt52ReasoningEffort = "high"
     static let defaultGpt52FastMode = false
     static let defaultGemini31ProThinkingLevel = "high"
-    static let defaultGemini3FlashThinkingLevel = "high"
+    static let defaultGemini35FlashThinkingLevel = "medium"
     static let defaultK26ReasoningEnabled = true
     static let defaultClaudeMaxBudgetMode = false
     static let defaultAllowRemote = false
@@ -128,12 +128,12 @@ enum AppPreferences {
         return defaults.string(forKey: gemini31ProThinkingLevelKey) ?? defaultGemini31ProThinkingLevel
     }
 
-    static var gemini3FlashThinkingLevel: String {
+    static var gemini35FlashThinkingLevel: String {
         let defaults = UserDefaults.standard
-        guard defaults.object(forKey: gemini3FlashThinkingLevelKey) != nil else {
-            return defaultGemini3FlashThinkingLevel
+        guard defaults.object(forKey: gemini35FlashThinkingLevelKey) != nil else {
+            return defaultGemini35FlashThinkingLevel
         }
-        return defaults.string(forKey: gemini3FlashThinkingLevelKey) ?? defaultGemini3FlashThinkingLevel
+        return defaults.string(forKey: gemini35FlashThinkingLevelKey) ?? defaultGemini35FlashThinkingLevel
     }
 
     static var k26ReasoningEnabled: Bool {

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -193,9 +193,9 @@ enum DroidProxyModelCatalog {
             levels: geminiProLevels
         ),
         DroidProxyModelDefinition(
-            baseModel: "gemini-3-flash-preview",
-            idSlug: "gemini-3-flash",
-            displayName: "Gemini 3 Flash",
+            baseModel: "gemini-3.5-flash-preview",
+            idSlug: "gemini-3.5-flash",
+            displayName: "Gemini 3.5 Flash",
             maxOutputTokens: 65536,
             provider: "google",
             providerKey: "gemini",

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -196,7 +196,7 @@ enum DroidProxyModelCatalog {
             baseModel: "gemini-3.5-flash",
             idSlug: "gemini-3.5-flash",
             displayName: "Gemini 3.5 Flash",
-            maxOutputTokens: 65536,
+            maxOutputTokens: 65535,
             provider: "google",
             providerKey: "gemini",
             baseURL: "http://localhost:8317",

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -193,7 +193,7 @@ enum DroidProxyModelCatalog {
             levels: geminiProLevels
         ),
         DroidProxyModelDefinition(
-            baseModel: "gemini-3.5-flash-preview",
+            baseModel: "gemini-3.5-flash",
             idSlug: "gemini-3.5-flash",
             displayName: "Gemini 3.5 Flash",
             maxOutputTokens: 65536,

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -519,7 +519,7 @@ struct SettingsView: View {
     @AppStorage(AppPreferences.gpt54FastModeKey) private var gpt54FastMode = AppPreferences.defaultGpt54FastMode
     @AppStorage(AppPreferences.gpt55FastModeKey) private var gpt55FastMode = AppPreferences.defaultGpt55FastMode
     @AppStorage(AppPreferences.gemini31ProThinkingLevelKey) private var gemini31ProThinkingLevel = AppPreferences.defaultGemini31ProThinkingLevel
-    @AppStorage(AppPreferences.gemini3FlashThinkingLevelKey) private var gemini3FlashThinkingLevel = AppPreferences.defaultGemini3FlashThinkingLevel
+    @AppStorage(AppPreferences.gemini35FlashThinkingLevelKey) private var gemini35FlashThinkingLevel = AppPreferences.defaultGemini35FlashThinkingLevel
     @AppStorage(AppPreferences.k26ReasoningEnabledKey) private var k26ReasoningEnabled = AppPreferences.defaultK26ReasoningEnabled
     @AppStorage(AppPreferences.allowRemoteKey) private var allowRemote = AppPreferences.defaultAllowRemote
     @AppStorage(AppPreferences.secretKeyKey) private var secretKey = AppPreferences.defaultSecretKey
@@ -1069,8 +1069,8 @@ struct SettingsView: View {
                                         tint: geminiEffortSelectionColor
                                     )
                                     effortPickerRow(
-                                        "Gemini 3 Flash thinking level",
-                                        selection: $gemini3FlashThinkingLevel,
+                                        "Gemini 3.5 Flash thinking level",
+                                        selection: $gemini35FlashThinkingLevel,
                                         options: ["minimal", "low", "medium", "high"],
                                         tint: geminiEffortSelectionColor
                                     )

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -698,8 +698,8 @@ class ThinkingProxy {
         switch model {
         case "gemini-3.1-pro-preview":
             return AppPreferences.gemini31ProThinkingLevel
-        case "gemini-3-flash-preview":
-            return AppPreferences.gemini3FlashThinkingLevel
+        case "gemini-3.5-flash-preview":
+            return AppPreferences.gemini35FlashThinkingLevel
         default:
             return nil
         }

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -698,7 +698,7 @@ class ThinkingProxy {
         switch model {
         case "gemini-3.1-pro-preview":
             return AppPreferences.gemini31ProThinkingLevel
-        case "gemini-3.5-flash-preview":
+        case "gemini-3.5-flash":
             return AppPreferences.gemini35FlashThinkingLevel
         default:
             return nil

--- a/website/src/components/InstallSection.tsx
+++ b/website/src/components/InstallSection.tsx
@@ -43,7 +43,7 @@ const codePlain = `// What "Apply" writes for you — no need to touch this your
     "maxOutputTokens": 65536,
     "provider": "openai"
   }
-  // + GPT 5.3 Codex, GPT 5.4, Gemini 3 Flash
+  // + GPT 5.3 Codex, GPT 5.4, Gemini 3.5 Flash
 ]`
 
 const codeHtml = `<span class="c">// What "Apply" writes for you — no need to touch this yourself.</span>
@@ -88,7 +88,7 @@ const codeHtml = `<span class="c">// What "Apply" writes for you — no need to 
     <span class="k">"maxOutputTokens"</span>: <span class="n">65536</span>,
     <span class="k">"provider"</span>: <span class="s">"openai"</span>
   }
-  <span class="c">// + GPT 5.3 Codex, GPT 5.4, Gemini 3 Flash</span>
+  <span class="c">// + GPT 5.3 Codex, GPT 5.4, Gemini 3.5 Flash</span>
 ]`
 
 export default function InstallSection() {

--- a/website/src/components/ModelsSection.tsx
+++ b/website/src/components/ModelsSection.tsx
@@ -60,7 +60,7 @@ const models = [
     name: 'Gemini 3.5 Flash',
     id: 'gemini-3.5-flash',
     levels: ['minimal', 'low', 'medium', 'high'],
-    max: '65,536',
+    max: '65,535',
     provider: 'Google',
   },
   {

--- a/website/src/components/ModelsSection.tsx
+++ b/website/src/components/ModelsSection.tsx
@@ -57,8 +57,8 @@ const models = [
   },
   {
     icon: '/assets/icon-gemini.png',
-    name: 'Gemini 3 Flash',
-    id: 'gemini-3-flash-preview',
+    name: 'Gemini 3.5 Flash',
+    id: 'gemini-3.5-flash-preview',
     levels: ['minimal', 'low', 'medium', 'high'],
     max: '65,536',
     provider: 'Google',

--- a/website/src/components/ModelsSection.tsx
+++ b/website/src/components/ModelsSection.tsx
@@ -58,7 +58,7 @@ const models = [
   {
     icon: '/assets/icon-gemini.png',
     name: 'Gemini 3.5 Flash',
-    id: 'gemini-3.5-flash-preview',
+    id: 'gemini-3.5-flash',
     levels: ['minimal', 'low', 'medium', 'high'],
     max: '65,536',
     provider: 'Google',


### PR DESCRIPTION
This PR updates Gemini 3 Flash to 3.5 Flash across the codebase, including app logic, UI, website, and documentation. It also updates the thinking levels and sets the default level for 3.5 Flash to medium.