### PR TITLE
Hand thinking control to Droid CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,40 +50,26 @@ Typical request flow:
 
 ### Current ThinkingProxy behavior
 
-`ThinkingProxy.swift` no longer implements the old `-thinking-N` suffix parser described in older docs.
+Reasoning effort is owned by **Droid CLI**, not the proxy. Each Factory custom model is registered with native reasoning metadata (`enableThinking`, `supportedReasoningEfforts`, `defaultReasoningEffort`, `reasoningEffort`) so Droid's per-session selector exposes every level the model supports, and Droid sends the chosen value in the request body. The proxy does **not** inject `thinking`, `reasoning`, `reasoning_effort`, `output_config`, `budget_tokens`, or `generationConfig.thinkingConfig` for any model — it forwards the request unchanged.
 
-What it does today:
+What it still does today:
 
-- Inspects `POST` JSON requests for supported Claude, Codex GPT, Gemini, and Kimi models
-- **Claude adaptive thinking** for models whose name contains `opus-4-7`, `opus-4-6`, or `sonnet-4-6`:
-  - Injects `"thinking":{"type":"adaptive"}` (Opus 4.7 gets `{"type":"adaptive","display":"summarized"}`)
-  - Injects `"output_config":{"effort":"..."}`
-  - Forces `"stream":true`
-  - Reads effort from `AppPreferences.opus47ThinkingEffort`, `AppPreferences.opus46ThinkingEffort`, or `AppPreferences.sonnet46ThinkingEffort`
-- **Claude classic thinking** for models whose name contains `opus-4-5` (which does not support adaptive thinking):
-  - Injects `"thinking":{"type":"enabled","budget_tokens":N}` plus a matching `"max_tokens"`, mapped from `AppPreferences.opus45ThinkingEffort` (low/medium/high/max → fixed budget/max-token pairs, see `opus45ClassicBudget`)
-  - Forces `"stream":true`
 - **Anthropic-Beta rewriting**: When a Claude request has `thinking.type` of `enabled`/`adaptive`/`auto`, the proxy strips `redact-thinking-2026-02-12` from the `Anthropic-Beta` header and appends the visible-thinking beta list (interleaved-thinking, prompt-caching-scope, fast-mode, etc.). Without this, Claude emits only signed empty thinking blocks.
-- **Codex reasoning** for exact models `gpt-5.2`, `gpt-5.3-codex`, `gpt-5.4`, and `gpt-5.5`:
-  - Injects `"reasoning":{"effort":"..."}`
-  - Reads effort from `AppPreferences.gpt52ReasoningEffort`, `AppPreferences.gpt53CodexReasoningEffort`, `AppPreferences.gpt54ReasoningEffort`, or `AppPreferences.gpt55ReasoningEffort`
-- **Gemini thinking levels** for `gemini-3.1-pro-preview` and `gemini-3-flash-preview`:
-  - Rewrites the model name to append a suffix (e.g. `gemini-3.1-pro-preview(high)`) which CLIProxyAPIPlus parses via its `ParseSuffix` logic
-  - Reads level from `AppPreferences.gemini31ProThinkingLevel` or `AppPreferences.gemini3FlashThinkingLevel`
-  - Also rewrites `/v1/responses` (and `/api/v1/responses`) to `/v1/chat/completions` for Gemini models since CLIProxyAPIPlus does not support Gemini via the Responses API
-- **Kimi reasoning** for `kimi-k2.6`:
-  - Injects a top-level `"reasoning_effort":"high"` when `AppPreferences.k26ReasoningEnabled` is true; passes through unchanged otherwise (k2.6 only has a boolean toggle, not an effort picker)
-- **Service tier (fast mode)** for Responses API paths (`/v1/responses`, `/api/v1/responses`): injects `"service_tier":"priority"` for `gpt-5.2`, `gpt-5.3-codex`, `gpt-5.4`, or `gpt-5.5` when `AppPreferences.gpt52FastMode`, `AppPreferences.gpt53CodexFastMode`, `AppPreferences.gpt54FastMode`, or `AppPreferences.gpt55FastMode` is enabled and the client did not already set `service_tier`
-- **Factory advanced variants**: When a request's model matches a `DroidProxyModelCatalog.advancedVariant` (e.g. `claude-opus-4-7(high)`), the proxy strips the level suffix, rewrites the JSON `model`, and routes through the matching Claude/Codex/Gemini/Kimi injection path with the variant's level overriding the AppPreferences default
-- Preserves JSON key order by editing the raw JSON string instead of re-serializing (critical for Anthropic's prompt cache)
-- **Max Budget Mode**: When `AppPreferences.claudeMaxBudgetMode` is enabled, the Sonnet 4.6 / Opus 4.6 adaptive path is replaced with classic extended thinking — `"thinking":{"type":"enabled","budget_tokens":63999}`, `"max_tokens":64000`, `"output_config":{"effort":"max"}`, and forced streaming. Opus 4.7 is unaffected and continues to receive `thinking.type=adaptive` with `output_config.effort` from `AppPreferences.opus47ThinkingEffort`.
+- **Service tier (fast mode)** for Responses API paths (`/v1/responses`, `/api/v1/responses`): injects `"service_tier":"priority"` for `gpt-5.2`, `gpt-5.3-codex`, `gpt-5.4`, or `gpt-5.5` when `AppPreferences.gpt52FastMode`, `AppPreferences.gpt53CodexFastMode`, `AppPreferences.gpt54FastMode`, or `AppPreferences.gpt55FastMode` is enabled and the client did not already set `service_tier`. Fast mode is API priority and is independent of reasoning effort.
+- **Gemini path rewrite**: `/v1/responses` (and `/api/v1/responses`) are rewritten to `/v1/chat/completions` for Gemini models since CLIProxyAPIPlus does not support Gemini via the Responses API endpoint.
+- **Amp routing**: see the `Amp routing` section below.
+- **Per-request reasoning log** to `/tmp/droidproxy-debug.log`: each `POST` emits a `REQUEST REASONING:` line that extracts just `reasoning` / `reasoning_effort` / `thinking` / `output_config` / `service_tier` / `generationConfig` from the parsed body so the actual values Droid is sending are visible without dumping the whole prompt. Example: `REQUEST REASONING: model=gpt-5.5 reasoning={"effort":"xhigh","summary":"auto"}`.
+- Preserves JSON key order by editing the raw JSON string instead of re-serializing (critical for Anthropic's prompt cache). The remaining helpers (`injectJSONField`, `findTopLevelFieldLocation`, etc.) exist for `processOpenAIFastMode`.
 
-What it does not do anymore:
+What it no longer does (removed in the Droid-CLI-thinking refactor):
 
-- It does not strip or normalize model suffixes for unsupported models
-- It does not send `thinking.budget_tokens` to Opus 4.6 or 4.7 (those use adaptive thinking only — budget_tokens is rejected). Opus 4.5 and the Max Budget override deliberately *do* use `budget_tokens`.
-- It does not add `anthropic-beta` interleaved-thinking headers manually for adaptive models (adaptive thinking enables interleaving automatically; the Anthropic-Beta rewrite above is about removing `redact-thinking-2026-02-12`)
-- It does not implement the old `-thinking-N` / suffix-based branching documented in stale docs
+- No Claude adaptive thinking injection (Opus 4.7 / 4.6 / Sonnet 4.6 — `thinking` + `output_config`)
+- No Opus 4.5 classic `thinking.budget_tokens` injection
+- No Codex `reasoning.effort` injection
+- No Gemini `generationConfig.thinkingConfig` injection
+- No Kimi `reasoning_effort` injection
+- No `claude-opus-4-7(high)` / `gpt-5.2(xhigh)` etc. “advanced variant” suffix parsing — every level now ships in the single base entry via Droid CLI metadata
+- No Max Budget Mode override
 
 ### Amp routing
 
@@ -128,11 +114,11 @@ Behavior to know:
 | `src/Sources/main.swift` | NSApplication entry point that instantiates `AppDelegate` and calls `NSApplicationMain`. |
 | `src/Sources/AppDelegate.swift` | App lifecycle, menu bar UI, settings window, notifications, Sparkle updater, auth-directory watcher, startup ordering for the two local servers. |
 | `src/Sources/ServerManager.swift` | Starts/stops bundled `cli-proxy-api-plus`, captures logs, merges config, handles provider enable/disable, runs Claude/Codex/Gemini login commands, and kills orphaned backend processes. |
-| `src/Sources/ThinkingProxy.swift` | Raw TCP HTTP proxy for thinking/reasoning injection, Anthropic-Beta header rewriting, Gemini path rewriting, factory-advanced variant routing, and Amp request/response rewriting. |
-| `src/Sources/DroidProxyModelCatalog.swift` | Authoritative catalog of DroidProxy-exposed models (base + advanced variants per reasoning/thinking level). Powers Settings entries when `factoryAdvancedModels` is on and `ThinkingProxy.advancedVariant` lookups. |
-| `src/Sources/SettingsView.swift` | SwiftUI settings UI for server status, launch-at-login, provider toggles, auth flows, per-model effort/level pickers, Kimi reasoning toggle, Max Budget Mode, factory-advanced-models toggle, OLED theme, background opacity, and remote-access settings. |
+| `src/Sources/ThinkingProxy.swift` | Raw TCP HTTP proxy that forwards requests to CLIProxyAPIPlus. Rewrites the Anthropic-Beta header to drop `redact-thinking-2026-02-12` on Claude thinking requests, injects `service_tier=priority` on enabled Codex fast-mode models, rewrites Gemini `/v1/responses` to `/v1/chat/completions`, handles Amp request/response rewriting, and emits a `REQUEST REASONING` log line per request. Does not inject reasoning or thinking fields. |
+| `src/Sources/DroidProxyModelCatalog.swift` | Authoritative catalog of DroidProxy-exposed models. Each `DroidProxyModelDefinition` carries its supported `levels` plus a `defaultLevelValue`, and `settingsEntry` always embeds Factory's native reasoning metadata (`enableThinking`, `supportedReasoningEfforts`, `defaultReasoningEffort`, `reasoningEffort`) so Droid CLI's per-session selector can expose the full level set. |
+| `src/Sources/SettingsView.swift` | SwiftUI settings UI for server status, launch-at-login, provider toggles, auth flows, the Codex fast-mode (`service_tier=priority`) subsection, the Factory custom-models Apply button, the Challenger plugin Apply button, OLED theme, background opacity, and remote-access settings. No thinking/reasoning selectors — those live in Droid CLI. |
 | `src/Sources/AuthStatus.swift` | `AuthManager`, account parsing, expiry detection, file deletion, and per-account disabled-state updates. |
-| `src/Sources/AppPreferences.swift` | UserDefaults-backed preferences: effort/level for Opus 4.7/4.6/4.5, Sonnet 4.6, GPT 5.2/5.3-codex/5.4/5.5, Gemini 3.1 Pro, Gemini 3 Flash; Kimi K2.6 enabled toggle; fast-mode toggles for GPT 5.2/5.3-codex/5.4/5.5; `claudeMaxBudgetMode`, `allowRemote`, `secretKey`, `oledTheme`, `factoryAdvancedModels`, `backgroundOpacity`; and the usage probe controls (`showUsageInMenuBar`, `usageAutoRefreshSeconds`). |
+| `src/Sources/AppPreferences.swift` | UserDefaults-backed preferences: fast-mode toggles for GPT 5.2/5.3-codex/5.4/5.5; `allowRemote`, `secretKey`, `oledTheme`, `backgroundOpacity`; and the usage probe controls (`showUsageInMenuBar`, `usageAutoRefreshSeconds`). No thinking-effort keys — reasoning is driven entirely by Droid CLI. |
 | `src/Sources/ClaudeUsageProbe.swift` | Hits `https://api.anthropic.com/api/oauth/usage` with the access token from `~/.cli-proxy-api/claude-*.json`. Handles OAuth refresh against `platform.claude.com/v1/oauth/token` (atomic write back to the auth file) and decodes the flat-keyed response shape (`five_hour`, `seven_day_*`). |
 | `src/Sources/CodexUsageProbe.swift` | Spawns `codex -s read-only -a untrusted app-server` as a child process and issues line-delimited JSON-RPC (`initialize` + `account/rateLimits/read`) to read Codex/ChatGPT rate limit windows. Requires the `codex` CLI to be installed and logged in. |
 | `src/Sources/UsageStore.swift` | `@MainActor` singleton that fan-outs to both probes in parallel, debounces overlapping refreshes (cancels in-flight task before starting a new one), and schedules a repeating timer based on `AppPreferences.usageAutoRefreshSeconds` (skips scheduling when set to 0/Manual). Posts `usageUpdated` notifications for UI consumers. |

--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -1,111 +1,30 @@
 import Foundation
 
 enum AppPreferences {
-    static let opus47ThinkingEffortKey = "opus47ThinkingEffort"
-    static let opus46ThinkingEffortKey = "opus46ThinkingEffort"
-    static let opus45ThinkingEffortKey = "opus45ThinkingEffort"
-    static let sonnet46ThinkingEffortKey = "sonnet46ThinkingEffort"
-    static let gpt53CodexReasoningEffortKey = "gpt53CodexReasoningEffort"
-    static let gpt54ReasoningEffortKey = "gpt54ReasoningEffort"
-    static let gpt55ReasoningEffortKey = "gpt55ReasoningEffort"
+    static let gpt52FastModeKey = "gpt52FastMode"
     static let gpt53CodexFastModeKey = "gpt53CodexFastMode"
     static let gpt54FastModeKey = "gpt54FastMode"
     static let gpt55FastModeKey = "gpt55FastMode"
-    static let gemini31ProThinkingLevelKey = "gemini31ProThinkingLevel"
-    static let gemini3FlashThinkingLevelKey = "gemini3FlashThinkingLevel"
-    static let k26ReasoningEnabledKey = "k26ReasoningEnabled"
-    static let claudeMaxBudgetModeKey = "claudeMaxBudgetMode"
     static let allowRemoteKey = "allowRemote"
     static let secretKeyKey = "secretKey"
     static let oledThemeKey = "oledTheme"
-    static let factoryAdvancedModelsKey = "factoryAdvancedModels"
     static let backgroundOpacityKey = "backgroundOpacity"
-    static let defaultOledTheme = false
-    static let defaultFactoryAdvancedModels = false
-    static let defaultBackgroundOpacity = 0.55
-    static let defaultOpus47ThinkingEffort = "xhigh"
-    static let defaultOpus46ThinkingEffort = "max"
-    static let defaultOpus45ThinkingEffort = "high"
-    static let defaultSonnet46ThinkingEffort = "high"
-    static let defaultGpt53CodexReasoningEffort = "high"
-    static let defaultGpt54ReasoningEffort = "high"
-    static let defaultGpt55ReasoningEffort = "high"
+    static let showUsageInMenuBarKey = "showUsageInMenuBar"
+    static let usageAutoRefreshSecondsKey = "usageAutoRefreshSeconds"
+
+    static let defaultGpt52FastMode = false
     static let defaultGpt53CodexFastMode = false
     static let defaultGpt54FastMode = false
     static let defaultGpt55FastMode = false
-    static let gpt52ReasoningEffortKey = "gpt52ReasoningEffort"
-    static let gpt52FastModeKey = "gpt52FastMode"
-    static let defaultGpt52ReasoningEffort = "high"
-    static let defaultGpt52FastMode = false
-    static let defaultGemini31ProThinkingLevel = "high"
-    static let defaultGemini3FlashThinkingLevel = "high"
-    static let defaultK26ReasoningEnabled = true
-    static let defaultClaudeMaxBudgetMode = false
     static let defaultAllowRemote = false
     static let defaultSecretKey = ""
-    static let showUsageInMenuBarKey = "showUsageInMenuBar"
-    static let usageAutoRefreshSecondsKey = "usageAutoRefreshSeconds"
+    static let defaultOledTheme = false
+    static let defaultBackgroundOpacity = 0.55
     static let defaultShowUsageInMenuBar = true
     static let defaultUsageAutoRefreshSeconds = 300
 
-    static var showUsageInMenuBar: Bool {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: showUsageInMenuBarKey) != nil else { return defaultShowUsageInMenuBar }
-        return defaults.bool(forKey: showUsageInMenuBarKey)
-    }
-
-    static var usageAutoRefreshSeconds: Int {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: usageAutoRefreshSecondsKey) != nil else { return defaultUsageAutoRefreshSeconds }
-        return defaults.integer(forKey: usageAutoRefreshSecondsKey)
-    }
-
-    static var opus47ThinkingEffort: String {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: opus47ThinkingEffortKey) != nil else {
-            return defaultOpus47ThinkingEffort
-        }
-        return defaults.string(forKey: opus47ThinkingEffortKey) ?? defaultOpus47ThinkingEffort
-    }
-
-    static var opus46ThinkingEffort: String {
-        UserDefaults.standard.string(forKey: opus46ThinkingEffortKey) ?? defaultOpus46ThinkingEffort
-    }
-
-    static var opus45ThinkingEffort: String {
-        UserDefaults.standard.string(forKey: opus45ThinkingEffortKey) ?? defaultOpus45ThinkingEffort
-    }
-
-    static var sonnet46ThinkingEffort: String {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: sonnet46ThinkingEffortKey) != nil else {
-            return defaultSonnet46ThinkingEffort
-        }
-        return defaults.string(forKey: sonnet46ThinkingEffortKey) ?? defaultSonnet46ThinkingEffort
-    }
-
-    static var gpt53CodexReasoningEffort: String {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: gpt53CodexReasoningEffortKey) != nil else {
-            return defaultGpt53CodexReasoningEffort
-        }
-        return defaults.string(forKey: gpt53CodexReasoningEffortKey) ?? defaultGpt53CodexReasoningEffort
-    }
-
-    static var gpt54ReasoningEffort: String {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: gpt54ReasoningEffortKey) != nil else {
-            return defaultGpt54ReasoningEffort
-        }
-        return defaults.string(forKey: gpt54ReasoningEffortKey) ?? defaultGpt54ReasoningEffort
-    }
-
-    static var gpt55ReasoningEffort: String {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: gpt55ReasoningEffortKey) != nil else {
-            return defaultGpt55ReasoningEffort
-        }
-        return defaults.string(forKey: gpt55ReasoningEffortKey) ?? defaultGpt55ReasoningEffort
+    static var gpt52FastMode: Bool {
+        UserDefaults.standard.bool(forKey: gpt52FastModeKey)
     }
 
     static var gpt53CodexFastMode: Bool {
@@ -120,52 +39,6 @@ enum AppPreferences {
         UserDefaults.standard.bool(forKey: gpt55FastModeKey)
     }
 
-    static var gemini31ProThinkingLevel: String {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: gemini31ProThinkingLevelKey) != nil else {
-            return defaultGemini31ProThinkingLevel
-        }
-        return defaults.string(forKey: gemini31ProThinkingLevelKey) ?? defaultGemini31ProThinkingLevel
-    }
-
-    static var gemini3FlashThinkingLevel: String {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: gemini3FlashThinkingLevelKey) != nil else {
-            return defaultGemini3FlashThinkingLevel
-        }
-        return defaults.string(forKey: gemini3FlashThinkingLevelKey) ?? defaultGemini3FlashThinkingLevel
-    }
-
-    static var k26ReasoningEnabled: Bool {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: k26ReasoningEnabledKey) != nil else {
-            return defaultK26ReasoningEnabled
-        }
-        return defaults.bool(forKey: k26ReasoningEnabledKey)
-    }
-
-    static var gpt52ReasoningEffort: String {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: gpt52ReasoningEffortKey) != nil else {
-            return defaultGpt52ReasoningEffort
-        }
-        return defaults.string(forKey: gpt52ReasoningEffortKey) ?? defaultGpt52ReasoningEffort
-    }
-
-    static var gpt52FastMode: Bool {
-        UserDefaults.standard.bool(forKey: gpt52FastModeKey)
-    }
-
-    static var backgroundOpacity: Double {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: backgroundOpacityKey) != nil else { return defaultBackgroundOpacity }
-        return defaults.double(forKey: backgroundOpacityKey)
-    }
-
-    static var claudeMaxBudgetMode: Bool {
-        UserDefaults.standard.bool(forKey: claudeMaxBudgetModeKey)
-    }
-
     static var allowRemote: Bool {
         UserDefaults.standard.bool(forKey: allowRemoteKey)
     }
@@ -176,5 +49,23 @@ enum AppPreferences {
             return defaultSecretKey
         }
         return defaults.string(forKey: secretKeyKey) ?? defaultSecretKey
+    }
+
+    static var backgroundOpacity: Double {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: backgroundOpacityKey) != nil else { return defaultBackgroundOpacity }
+        return defaults.double(forKey: backgroundOpacityKey)
+    }
+
+    static var showUsageInMenuBar: Bool {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: showUsageInMenuBarKey) != nil else { return defaultShowUsageInMenuBar }
+        return defaults.bool(forKey: showUsageInMenuBarKey)
+    }
+
+    static var usageAutoRefreshSeconds: Int {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: usageAutoRefreshSecondsKey) != nil else { return defaultUsageAutoRefreshSeconds }
+        return defaults.integer(forKey: usageAutoRefreshSecondsKey)
     }
 }

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -22,50 +22,33 @@ struct DroidProxyModelDefinition: Equatable {
     let providerKey: String
     let baseURL: String
     let kind: DroidProxyModelKind
-    let levelLabel: String
     let levels: [DroidProxyThinkingLevel]
+    let defaultLevelValue: String
 
     var simpleID: String {
         "custom:droidproxy:\(idSlug)"
     }
 
-    func advancedID(for level: DroidProxyThinkingLevel) -> String {
-        "custom:droidproxy:\(idSlug)-\(level.value)"
-    }
-
-    func modelAlias(for level: DroidProxyThinkingLevel) -> String {
-        "\(baseModel)(\(level.value))"
-    }
-
-    var simpleSettingsEntry: [String: Any] {
-        settingsEntry(id: simpleID, model: baseModel, displayName: "DroidProxy: \(displayName)")
-    }
-
-    func advancedSettingsEntry(for level: DroidProxyThinkingLevel) -> [String: Any] {
-        settingsEntry(
-            id: advancedID(for: level),
-            model: modelAlias(for: level),
-            displayName: "DroidProxy: \(displayName) - \(level.displayName) \(levelLabel)"
-        )
-    }
-
-    private func settingsEntry(id: String, model: String, displayName: String) -> [String: Any] {
-        [
-            "model": model,
-            "id": id,
+    /// Settings entry that embeds Factory's native reasoning metadata so Droid's
+    /// per-session reasoning selector picks up the supported levels for this model.
+    var settingsEntry: [String: Any] {
+        var entry: [String: Any] = [
+            "model": baseModel,
+            "id": simpleID,
             "baseUrl": baseURL,
             "apiKey": "dummy-not-used",
-            "displayName": displayName,
+            "displayName": "DroidProxy: \(displayName)",
             "maxOutputTokens": maxOutputTokens,
             "noImageSupport": false,
             "provider": provider
         ]
+        guard levels.count > 1 else { return entry }
+        entry["enableThinking"] = true
+        entry["supportedReasoningEfforts"] = levels.map(\.value)
+        entry["defaultReasoningEffort"] = defaultLevelValue
+        entry["reasoningEffort"] = defaultLevelValue
+        return entry
     }
-}
-
-struct DroidProxyModelVariant {
-    let definition: DroidProxyModelDefinition
-    let level: DroidProxyThinkingLevel
 }
 
 enum DroidProxyModelCatalog {
@@ -93,8 +76,8 @@ enum DroidProxyModelCatalog {
             providerKey: "claude",
             baseURL: "http://localhost:8317",
             kind: .claudeAdaptive,
-            levelLabel: "Effort",
-            levels: claudeAdvancedLevels
+            levels: claudeAdvancedLevels,
+            defaultLevelValue: "xhigh"
         ),
         DroidProxyModelDefinition(
             baseModel: "claude-opus-4-6",
@@ -105,8 +88,8 @@ enum DroidProxyModelCatalog {
             providerKey: "claude",
             baseURL: "http://localhost:8317",
             kind: .claudeAdaptive,
-            levelLabel: "Effort",
-            levels: claudeClassicLevels
+            levels: claudeClassicLevels,
+            defaultLevelValue: "max"
         ),
         DroidProxyModelDefinition(
             baseModel: "claude-opus-4-5-20251101",
@@ -117,8 +100,8 @@ enum DroidProxyModelCatalog {
             providerKey: "claude",
             baseURL: "http://localhost:8317",
             kind: .claudeClassic,
-            levelLabel: "Effort",
-            levels: claudeClassicLevels
+            levels: claudeClassicLevels,
+            defaultLevelValue: "high"
         ),
         DroidProxyModelDefinition(
             baseModel: "claude-sonnet-4-6",
@@ -129,8 +112,8 @@ enum DroidProxyModelCatalog {
             providerKey: "claude",
             baseURL: "http://localhost:8317",
             kind: .claudeAdaptive,
-            levelLabel: "Effort",
-            levels: claudeClassicLevels
+            levels: claudeClassicLevels,
+            defaultLevelValue: "high"
         ),
         DroidProxyModelDefinition(
             baseModel: "gpt-5.2",
@@ -141,8 +124,8 @@ enum DroidProxyModelCatalog {
             providerKey: "codex",
             baseURL: "http://localhost:8317/v1",
             kind: .codex,
-            levelLabel: "Reasoning",
-            levels: codexLevels
+            levels: codexLevels,
+            defaultLevelValue: "high"
         ),
         DroidProxyModelDefinition(
             baseModel: "gpt-5.3-codex",
@@ -153,8 +136,8 @@ enum DroidProxyModelCatalog {
             providerKey: "codex",
             baseURL: "http://localhost:8317/v1",
             kind: .codex,
-            levelLabel: "Reasoning",
-            levels: codexLevels
+            levels: codexLevels,
+            defaultLevelValue: "high"
         ),
         DroidProxyModelDefinition(
             baseModel: "gpt-5.4",
@@ -165,8 +148,8 @@ enum DroidProxyModelCatalog {
             providerKey: "codex",
             baseURL: "http://localhost:8317/v1",
             kind: .codex,
-            levelLabel: "Reasoning",
-            levels: codexLevels
+            levels: codexLevels,
+            defaultLevelValue: "high"
         ),
         DroidProxyModelDefinition(
             baseModel: "gpt-5.5",
@@ -177,8 +160,8 @@ enum DroidProxyModelCatalog {
             providerKey: "codex",
             baseURL: "http://localhost:8317/v1",
             kind: .codex,
-            levelLabel: "Reasoning",
-            levels: codexLevels
+            levels: codexLevels,
+            defaultLevelValue: "high"
         ),
         DroidProxyModelDefinition(
             baseModel: "gemini-3.1-pro-preview",
@@ -189,8 +172,8 @@ enum DroidProxyModelCatalog {
             providerKey: "gemini",
             baseURL: "http://localhost:8317",
             kind: .gemini,
-            levelLabel: "Thinking",
-            levels: geminiProLevels
+            levels: geminiProLevels,
+            defaultLevelValue: "high"
         ),
         DroidProxyModelDefinition(
             baseModel: "gemini-3-flash-preview",
@@ -201,8 +184,8 @@ enum DroidProxyModelCatalog {
             providerKey: "gemini",
             baseURL: "http://localhost:8317",
             kind: .gemini,
-            levelLabel: "Thinking",
-            levels: geminiFlashLevels
+            levels: geminiFlashLevels,
+            defaultLevelValue: "high"
         ),
         DroidProxyModelDefinition(
             baseModel: "kimi-k2.6",
@@ -213,31 +196,22 @@ enum DroidProxyModelCatalog {
             providerKey: "kimi",
             baseURL: "http://localhost:8317/v1",
             kind: .kimi,
-            levelLabel: "Reasoning",
-            levels: kimiLevels
+            levels: kimiLevels,
+            defaultLevelValue: "high"
         )
     ]
 
-    static func settingsModels(advanced: Bool) -> [[String: Any]] {
-        if advanced {
-            return definitions.flatMap { definition in
-                definition.levels.map { definition.advancedSettingsEntry(for: $0) }
-            }
-        }
-        return definitions.map(\.simpleSettingsEntry)
+    static func settingsModels() -> [[String: Any]] {
+        definitions.map(\.settingsEntry)
     }
 
     static var allSettingsIDs: Set<String> {
-        Set(definitions.flatMap { definition in
-            [definition.simpleID] + definition.levels.map { definition.advancedID(for: $0) }
-        })
+        Set(definitions.map(\.simpleID))
     }
 
     static func providerKey(forSettingsModel model: [String: Any]) -> String? {
         if let id = model["id"] as? String,
-           let definition = definitions.first(where: { definition in
-               id == definition.simpleID || definition.levels.contains { definition.advancedID(for: $0) == id }
-           }) {
+           let definition = definitions.first(where: { $0.simpleID == id }) {
             return definition.providerKey
         }
 
@@ -246,30 +220,6 @@ enum DroidProxyModelCatalog {
         if name.hasPrefix("gpt") { return "codex" }
         if name.hasPrefix("gemini") { return "gemini" }
         if name.hasPrefix("kimi-k2.6") { return "kimi" }
-        return nil
-    }
-
-    static func advancedVariant(for model: String) -> DroidProxyModelVariant? {
-        guard model.hasSuffix(")"),
-              let openIndex = model.lastIndex(of: "(") else {
-            return nil
-        }
-
-        let base = String(model[..<openIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
-        let levelStart = model.index(after: openIndex)
-        let levelEnd = model.index(before: model.endIndex)
-        let requestedLevel = String(model[levelStart..<levelEnd])
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-
-        guard !base.isEmpty, !requestedLevel.isEmpty else { return nil }
-
-        for definition in definitions where definition.baseModel == base {
-            if let level = definition.levels.first(where: { $0.value == requestedLevel }) {
-                return DroidProxyModelVariant(definition: definition, level: level)
-            }
-        }
-
         return nil
     }
 }

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -80,206 +80,6 @@ extension View {
     }
 }
 
-struct HazardStripesView: View {
-    let stripeColor: Color
-    let backgroundColor: Color
-    private let stripeWidth: CGFloat = 6
-    private let gap: CGFloat = 10
-
-    var body: some View {
-        GeometryReader { geo in
-            let totalWidth = geo.size.width + geo.size.height
-            let count = Int(totalWidth / (stripeWidth + gap)) + 2
-            ZStack {
-                backgroundColor
-                HStack(spacing: gap) {
-                    ForEach(0..<count, id: \.self) { _ in
-                        Rectangle()
-                            .fill(stripeColor)
-                            .frame(width: stripeWidth)
-                    }
-                }
-                .frame(width: totalWidth)
-                .rotationEffect(.degrees(-45))
-            }
-        }
-        .clipped()
-    }
-}
-
-struct MaxBudgetToggleView: View {
-    @Binding var isOn: Bool
-    @State private var isPulsing = false
-    @State private var showFlash = false
-    @State private var isPressed = false
-
-    private let dangerRed = Color(red: 0.9, green: 0.15, blue: 0.1)
-    private let hazardOrange = Color(red: 0.95, green: 0.4, blue: 0.1)
-    private let darkRed = Color(red: 0.5, green: 0.05, blue: 0.02)
-    private let buttonSize: CGFloat = 44
-
-    var body: some View {
-        VStack(spacing: 14) {
-            // Button row: label + big red 3D button
-            HStack(spacing: 12) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("MAX BUDGET MODE")
-                        .font(.system(size: 10, weight: .bold, design: .monospaced))
-                        .tracking(0.8)
-                        .foregroundColor(isOn ? dangerRed : .gray.opacity(0.6))
-                    Text("Opus 4.6 + Sonnet 4.6 · max budget_tokens + effort")
-                        .font(.system(size: 9))
-                        .foregroundColor(.gray.opacity(0.5))
-                }
-
-                Spacer()
-
-                // The Big Red Button
-                Button {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        isOn.toggle()
-                    }
-                    if isOn {
-                        showFlash = true
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                            withAnimation(.easeOut(duration: 0.15)) {
-                                showFlash = false
-                            }
-                        }
-                        withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
-                            isPulsing = true
-                        }
-                    } else {
-                        withAnimation(.easeOut(duration: 0.2)) {
-                            isPulsing = false
-                        }
-                    }
-                } label: {
-                    ZStack {
-                        // Base shadow / depth (the "well" the button sits in)
-                        Circle()
-                            .fill(Color.black.opacity(0.6))
-                            .frame(width: buttonSize + 6, height: buttonSize + 6)
-
-                        // Outer ring - metallic bezel
-                        Circle()
-                            .fill(
-                                RadialGradient(
-                                    colors: [Color.gray.opacity(0.4), Color.gray.opacity(0.15), Color.black.opacity(0.3)],
-                                    center: .center,
-                                    startRadius: buttonSize * 0.35,
-                                    endRadius: buttonSize * 0.5
-                                )
-                            )
-                            .frame(width: buttonSize + 4, height: buttonSize + 4)
-
-                        // Main button face - 3D convex gradient
-                        Circle()
-                            .fill(
-                                RadialGradient(
-                                    colors: isOn
-                                        ? [dangerRed, dangerRed.opacity(0.85), darkRed]
-                                        : [Color(white: 0.35), Color(white: 0.22), Color(white: 0.12)],
-                                    center: .init(x: 0.4, y: 0.35),
-                                    startRadius: 0,
-                                    endRadius: buttonSize * 0.5
-                                )
-                            )
-                            .frame(width: buttonSize, height: buttonSize)
-                            .overlay(
-                                // Top highlight for 3D convexity
-                                Circle()
-                                    .fill(
-                                        LinearGradient(
-                                            colors: [Color.white.opacity(isOn ? 0.25 : 0.15), .clear],
-                                            startPoint: .top,
-                                            endPoint: .center
-                                        )
-                                    )
-                                    .frame(width: buttonSize - 4, height: buttonSize - 4)
-                            )
-
-                        // Power icon on the button
-                        Image(systemName: "power")
-                            .font(.system(size: 16, weight: .bold))
-                            .foregroundColor(isOn ? Color.white : Color.gray.opacity(0.5))
-
-                        // Ignition flash
-                        if showFlash {
-                            Circle()
-                                .fill(Color.white.opacity(0.6))
-                                .frame(width: buttonSize, height: buttonSize)
-                                .transition(.opacity)
-                        }
-                    }
-                    .scaleEffect(isPressed ? 0.92 : 1.0)
-                }
-                .buttonStyle(.plain)
-                .shadow(color: isOn ? dangerRed.opacity(isPulsing ? 0.7 : 0.25) : .clear, radius: isOn ? 12 : 0)
-                .animation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true), value: isPulsing)
-                .onHover { inside in
-                    if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                }
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { _ in
-                            withAnimation(.easeInOut(duration: 0.1)) { isPressed = true }
-                        }
-                        .onEnded { _ in
-                            withAnimation(.easeOut(duration: 0.15)) { isPressed = false }
-                        }
-                )
-            }
-
-            // Status banner (separate, only when active)
-            if isOn {
-                HStack(spacing: 6) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(size: 10, weight: .bold))
-                        .foregroundColor(hazardOrange)
-                        .opacity(isPulsing ? 1.0 : 0.6)
-                    Text("\u{26a1} BURNING THROUGH QUOTA")
-                        .font(.system(size: 9, weight: .bold, design: .monospaced))
-                        .tracking(0.8)
-                        .foregroundColor(dangerRed.opacity(0.9))
-                    Spacer()
-                    Text("ACTIVE")
-                        .font(.system(size: 8, weight: .black, design: .monospaced))
-                        .tracking(1.5)
-                        .foregroundColor(dangerRed)
-                }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background(
-                    ZStack {
-                        HazardStripesView(
-                            stripeColor: dangerRed.opacity(0.15),
-                            backgroundColor: Color.red.opacity(0.05)
-                        )
-                        RoundedRectangle(cornerRadius: 5)
-                            .fill(Color.black.opacity(0.3))
-                    }
-                )
-                .droidGlassCard(cornerRadius: 5, tint: dangerRed.opacity(0.25))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 5)
-                        .stroke(dangerRed.opacity(0.3), lineWidth: 1)
-                )
-                .transition(.opacity.combined(with: .move(edge: .top)))
-            }
-        }
-        .onAppear {
-            if isOn {
-                withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
-                    isPulsing = true
-                }
-            }
-        }
-        .help("Overrides Opus 4.6 and Sonnet 4.6 effort sliders with classic extended thinking (budget_tokens=63999, effort=max). Opus 4.7 keeps its own slider setting — max mode does not affect it. Ignition is cheap, fuel is not.")
-    }
-}
-
-
 /// A single account row with disable toggle and remove button
 struct AccountRowView: View {
     static let accent = Color(red: 0xF2/255, green: 0x7B/255, blue: 0x2F/255)
@@ -506,29 +306,16 @@ struct SettingsView: View {
     @ObservedObject var serverManager: ServerManager
     @StateObject private var authManager = AuthManager()
     @State private var launchAtLogin = false
-    @AppStorage(AppPreferences.opus47ThinkingEffortKey) private var opus47ThinkingEffort = AppPreferences.defaultOpus47ThinkingEffort
-    @AppStorage(AppPreferences.opus46ThinkingEffortKey) private var opus46ThinkingEffort = AppPreferences.defaultOpus46ThinkingEffort
-    @AppStorage(AppPreferences.opus45ThinkingEffortKey) private var opus45ThinkingEffort = AppPreferences.defaultOpus45ThinkingEffort
-    @AppStorage(AppPreferences.sonnet46ThinkingEffortKey) private var sonnet46ThinkingEffort = AppPreferences.defaultSonnet46ThinkingEffort
-    @AppStorage(AppPreferences.gpt52ReasoningEffortKey) private var gpt52ReasoningEffort = AppPreferences.defaultGpt52ReasoningEffort
-    @AppStorage(AppPreferences.gpt53CodexReasoningEffortKey) private var gpt53CodexReasoningEffort = AppPreferences.defaultGpt53CodexReasoningEffort
-    @AppStorage(AppPreferences.gpt54ReasoningEffortKey) private var gpt54ReasoningEffort = AppPreferences.defaultGpt54ReasoningEffort
-    @AppStorage(AppPreferences.gpt55ReasoningEffortKey) private var gpt55ReasoningEffort = AppPreferences.defaultGpt55ReasoningEffort
     @AppStorage(AppPreferences.gpt52FastModeKey) private var gpt52FastMode = AppPreferences.defaultGpt52FastMode
     @AppStorage(AppPreferences.gpt53CodexFastModeKey) private var gpt53CodexFastMode = AppPreferences.defaultGpt53CodexFastMode
     @AppStorage(AppPreferences.gpt54FastModeKey) private var gpt54FastMode = AppPreferences.defaultGpt54FastMode
     @AppStorage(AppPreferences.gpt55FastModeKey) private var gpt55FastMode = AppPreferences.defaultGpt55FastMode
-    @AppStorage(AppPreferences.gemini31ProThinkingLevelKey) private var gemini31ProThinkingLevel = AppPreferences.defaultGemini31ProThinkingLevel
-    @AppStorage(AppPreferences.gemini3FlashThinkingLevelKey) private var gemini3FlashThinkingLevel = AppPreferences.defaultGemini3FlashThinkingLevel
-    @AppStorage(AppPreferences.k26ReasoningEnabledKey) private var k26ReasoningEnabled = AppPreferences.defaultK26ReasoningEnabled
     @AppStorage(AppPreferences.allowRemoteKey) private var allowRemote = AppPreferences.defaultAllowRemote
     @AppStorage(AppPreferences.secretKeyKey) private var secretKey = AppPreferences.defaultSecretKey
-    @AppStorage(AppPreferences.claudeMaxBudgetModeKey) private var claudeMaxBudgetMode = AppPreferences.defaultClaudeMaxBudgetMode
     @AppStorage(AppPreferences.showUsageInMenuBarKey) private var showUsageInMenuBar = AppPreferences.defaultShowUsageInMenuBar
     @AppStorage(AppPreferences.usageAutoRefreshSecondsKey) private var usageAutoRefreshSeconds = AppPreferences.defaultUsageAutoRefreshSeconds
     @AppStorage(AppPreferences.oledThemeKey) private var oledTheme = AppPreferences.defaultOledTheme
     @AppStorage(AppPreferences.backgroundOpacityKey) private var backgroundOpacity = AppPreferences.defaultBackgroundOpacity
-    @AppStorage(AppPreferences.factoryAdvancedModelsKey) private var factoryAdvancedModels = AppPreferences.defaultFactoryAdvancedModels
     @State private var authenticatingService: ServiceType? = nil
     @State private var showingAuthResult = false
     @State private var authResultMessage = ""
@@ -539,14 +326,7 @@ struct SettingsView: View {
     @State private var factoryModelsInstalled = false
     @State private var challengerPluginInstalled = false
     @State private var remoteManagementExpanded = false
-    @State private var showingMaxBudgetWarning = false
-    @State private var claudeModelsExpanded = true
-    @State private var codexModelsExpanded = true
-    @State private var geminiModelsExpanded = true
-    @State private var opus47EffortExpanded = false
-    @State private var opus46EffortExpanded = false
-    @State private var opus45EffortExpanded = false
-    @State private var sonnet46EffortExpanded = false
+    @State private var codexFastModeExpanded = true
     private let claudeEffortSelectionColor = Color(red: 0xD9/255, green: 0x77/255, blue: 0x57/255)
     private let codexEffortSelectionColor = Color(red: 0x74/255, green: 0xAA/255, blue: 0x9C/255)
     private let geminiEffortSelectionColor = Color(red: 0x42/255, green: 0x85/255, blue: 0xF4/255)
@@ -715,20 +495,10 @@ struct SettingsView: View {
                             .controlSize(.small)
                         }
 
-                        Toggle("Advanced: add one Factory model entry per reasoning/thinking level", isOn: $factoryAdvancedModels)
-                            .toggleStyle(.checkbox)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .onChange(of: factoryAdvancedModels) { _ in
-                                factoryModelsInstalled = checkFactoryModelsInstalled()
-                                challengerPluginInstalled = checkChallengerPluginInstalled()
-                            }
-
-                        Text(factoryAdvancedModels
-                             ? "Apply writes separate Low/Medium/High/etc. model aliases into ~/.factory/settings.json."
-                             : "Apply writes the default DroidProxy model aliases into ~/.factory/settings.json.")
+                        Text("Apply writes DroidProxy model aliases into ~/.factory/settings.json. Each model exposes its full reasoning level set (low/medium/high/xhigh/max) directly in Factory's per-session selector — pick the level from Droid CLI, not here.")
                             .font(.caption2)
                             .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
                         }
 
                     HStack {
@@ -873,75 +643,6 @@ struct SettingsView: View {
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
 
-                    if serverManager.isProviderEnabled("claude") {
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack(spacing: 4) {
-                                Text("Model Settings")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                                Image(systemName: claudeModelsExpanded ? "chevron.down" : "chevron.right")
-                                    .font(.caption2)
-                                    .foregroundColor(.secondary)
-                                Spacer()
-                            }
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    claudeModelsExpanded.toggle()
-                                }
-                            }
-                            if claudeModelsExpanded {
-                                if factoryAdvancedModels {
-                                    advancedFactoryModelsNotice("Claude")
-                                } else {
-                                    MaxBudgetToggleView(isOn: $claudeMaxBudgetMode)
-                                        .onChange(of: claudeMaxBudgetMode) { enabled in
-                                            if enabled {
-                                                showingMaxBudgetWarning = true
-                                                opus46ThinkingEffort = "max"
-                                                sonnet46ThinkingEffort = "max"
-                                            }
-                                        }
-                                    collapsibleEffortPickerRow(
-                                        "Opus 4.7 thinking effort",
-                                        selection: $opus47ThinkingEffort,
-                                        options: ["low", "medium", "high", "xhigh", "max"],
-                                        tint: claudeEffortSelectionColor,
-                                        isExpanded: $opus47EffortExpanded
-                                    )
-                                    collapsibleEffortPickerRow(
-                                        "Opus 4.6 thinking effort",
-                                        selection: $opus46ThinkingEffort,
-                                        options: ["low", "medium", "high", "max"],
-                                        tint: claudeEffortSelectionColor,
-                                        isExpanded: $opus46EffortExpanded,
-                                        overrideBadge: claudeMaxBudgetMode ? "MAX MODE" : nil
-                                    )
-                                    .disabled(claudeMaxBudgetMode)
-                                    .opacity(claudeMaxBudgetMode ? 0.45 : 1.0)
-                                    collapsibleEffortPickerRow(
-                                        "Opus 4.5 thinking effort",
-                                        selection: $opus45ThinkingEffort,
-                                        options: ["low", "medium", "high", "max"],
-                                        tint: claudeEffortSelectionColor,
-                                        isExpanded: $opus45EffortExpanded
-                                    )
-                                    collapsibleEffortPickerRow(
-                                        "Sonnet 4.6 thinking effort",
-                                        selection: $sonnet46ThinkingEffort,
-                                        options: ["low", "medium", "high", "max"],
-                                        tint: claudeEffortSelectionColor,
-                                        isExpanded: $sonnet46EffortExpanded,
-                                        overrideBadge: claudeMaxBudgetMode ? "MAX MODE" : nil
-                                    )
-                                    .disabled(claudeMaxBudgetMode)
-                                    .opacity(claudeMaxBudgetMode ? 0.45 : 1.0)
-                                }
-                            }
-                        }
-                        .padding(.leading, 28)
-                    }
-
                     ServiceRow(
                         serviceType: .codex,
                         iconName: "icon-codex.png",
@@ -961,10 +662,10 @@ struct SettingsView: View {
                     if serverManager.isProviderEnabled("codex") {
                         VStack(alignment: .leading, spacing: 6) {
                             HStack(spacing: 4) {
-                                Text("Model Settings")
+                                Text("Fast Mode")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
-                                Image(systemName: codexModelsExpanded ? "chevron.down" : "chevron.right")
+                                Image(systemName: codexFastModeExpanded ? "chevron.down" : "chevron.right")
                                     .font(.caption2)
                                     .foregroundColor(.secondary)
                                 Spacer()
@@ -972,54 +673,30 @@ struct SettingsView: View {
                             .contentShape(Rectangle())
                             .onTapGesture {
                                 withAnimation(.easeInOut(duration: 0.2)) {
-                                    codexModelsExpanded.toggle()
+                                    codexFastModeExpanded.toggle()
                                 }
                             }
-                            if codexModelsExpanded {
-                                if factoryAdvancedModels {
-                                    advancedFactoryModelsNotice("Codex")
-                                    codexFastModeToggleRow(
-                                        "GPT 5.2",
-                                        isOn: $gpt52FastMode,
-                                        helpText: "Injects service_tier=priority for GPT 5.2 Responses API requests (Codex fast mode)"
-                                    )
-                                    codexFastModeToggleRow(
-                                        "GPT 5.3 Codex",
-                                        isOn: $gpt53CodexFastMode,
-                                        helpText: "Injects service_tier=priority for GPT 5.3 Codex Responses API requests (Codex fast mode)"
-                                    )
-                                    codexFastModeToggleRow(
-                                        "GPT 5.4",
-                                        isOn: $gpt54FastMode,
-                                        helpText: "Injects service_tier=priority for GPT 5.4 Responses API requests (Codex fast mode)"
-                                    )
-                                    codexFastModeToggleRow(
-                                        "GPT 5.5",
-                                        isOn: $gpt55FastMode,
-                                        helpText: "Injects service_tier=priority for GPT 5.5 Responses API requests (Codex fast mode)"
-                                    )
-                                } else {
-                                    codexReasoningEffortRow(
-                                        "GPT 5.2",
-                                        effortSelection: $gpt52ReasoningEffort,
-                                        fastMode: $gpt52FastMode
-                                    )
-                                    codexReasoningEffortRow(
-                                        "GPT 5.3 Codex",
-                                        effortSelection: $gpt53CodexReasoningEffort,
-                                        fastMode: $gpt53CodexFastMode
-                                    )
-                                    codexReasoningEffortRow(
-                                        "GPT 5.4",
-                                        effortSelection: $gpt54ReasoningEffort,
-                                        fastMode: $gpt54FastMode
-                                    )
-                                    codexReasoningEffortRow(
-                                        "GPT 5.5",
-                                        effortSelection: $gpt55ReasoningEffort,
-                                        fastMode: $gpt55FastMode
-                                    )
-                                }
+                            if codexFastModeExpanded {
+                                codexFastModeToggleRow(
+                                    "GPT 5.2",
+                                    isOn: $gpt52FastMode,
+                                    helpText: "Injects service_tier=priority for GPT 5.2 Responses API requests (Codex fast mode)"
+                                )
+                                codexFastModeToggleRow(
+                                    "GPT 5.3 Codex",
+                                    isOn: $gpt53CodexFastMode,
+                                    helpText: "Injects service_tier=priority for GPT 5.3 Codex Responses API requests (Codex fast mode)"
+                                )
+                                codexFastModeToggleRow(
+                                    "GPT 5.4",
+                                    isOn: $gpt54FastMode,
+                                    helpText: "Injects service_tier=priority for GPT 5.4 Responses API requests (Codex fast mode)"
+                                )
+                                codexFastModeToggleRow(
+                                    "GPT 5.5",
+                                    isOn: $gpt55FastMode,
+                                    helpText: "Injects service_tier=priority for GPT 5.5 Responses API requests (Codex fast mode)"
+                                )
                             }
                         }
                         .padding(.leading, 28)
@@ -1041,45 +718,6 @@ struct SettingsView: View {
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
 
-                    if serverManager.isProviderEnabled("gemini") {
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack(spacing: 4) {
-                                Text("Model Settings")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                                Image(systemName: geminiModelsExpanded ? "chevron.down" : "chevron.right")
-                                    .font(.caption2)
-                                    .foregroundColor(.secondary)
-                                Spacer()
-                            }
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    geminiModelsExpanded.toggle()
-                                }
-                            }
-                            if geminiModelsExpanded {
-                                if factoryAdvancedModels {
-                                    advancedFactoryModelsNotice("Gemini")
-                                } else {
-                                    effortPickerRow(
-                                        "Gemini 3.1 Pro thinking level",
-                                        selection: $gemini31ProThinkingLevel,
-                                        options: ["low", "medium", "high"],
-                                        tint: geminiEffortSelectionColor
-                                    )
-                                    effortPickerRow(
-                                        "Gemini 3 Flash thinking level",
-                                        selection: $gemini3FlashThinkingLevel,
-                                        options: ["minimal", "low", "medium", "high"],
-                                        tint: geminiEffortSelectionColor
-                                    )
-                                }
-                            }
-                        }
-                        .padding(.leading, 28)
-                    }
-
                     ServiceRow(
                         serviceType: .kimi,
                         iconName: "icon-kimi.svg",
@@ -1096,20 +734,6 @@ struct SettingsView: View {
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
 
-                    if serverManager.isProviderEnabled("kimi") {
-                        HStack {
-                            Text("K2.6 reasoning")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                            Spacer()
-                            Toggle("", isOn: $k26ReasoningEnabled)
-                                .toggleStyle(.switch)
-                                .controlSize(.mini)
-                                .tint(kimiEffortSelectionColor)
-                                .labelsHidden()
-                        }
-                        .padding(.leading, 28)
-                    }
                 }
                 .listRowBackground(glassRowBackground)
             }
@@ -1211,28 +835,9 @@ struct SettingsView: View {
         } message: {
             Text(authResultMessage)
         }
-        .alert("⚠️ MAX BUDGET MODE", isPresented: $showingMaxBudgetWarning) {
-            Button("Engage", role: .cancel) { }
-        } message: {
-            Text("Opus 4.6 and Sonnet 4.6 requests will bypass their effort sliders and revert to classic extended thinking with maximum budget_tokens and effort=max. Opus 4.7 keeps its own slider — Max Budget Mode does not apply to it. These requests will burn through your quota fast.")
-        }
     }
 
     // MARK: - Actions
-
-    @ViewBuilder
-    private func advancedFactoryModelsNotice(_ providerName: String) -> some View {
-        HStack(alignment: .top, spacing: 6) {
-            Image(systemName: "slider.horizontal.3")
-                .font(.caption)
-                .foregroundColor(.secondary)
-            Text("Advanced Factory models are on. Re-apply custom models to pick \(providerName) reasoning/thinking levels directly from Factory's model picker.")
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(.vertical, 4)
-    }
 
     @ViewBuilder
     private func codexFastModeToggleRow(_ title: String, isOn: Binding<Bool>, helpText: String) -> some View {
@@ -1249,136 +854,6 @@ struct SettingsView: View {
         .padding(.vertical, 2)
     }
 
-    @ViewBuilder
-    private func codexReasoningEffortRow(
-        _ title: String,
-        effortSelection: Binding<String>,
-        fastMode: Binding<Bool>
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text("\(title) reasoning effort")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                Spacer()
-                Toggle("Fast mode", isOn: fastMode)
-                    .toggleStyle(.checkbox)
-                    .font(.caption)
-                    .help("Injects service_tier=priority for \(title) Responses API requests (Codex fast mode)")
-            }
-            Picker("", selection: effortSelection) {
-                ForEach(["low", "medium", "high", "xhigh"], id: \.self) { option in
-                    Text(option).tag(option)
-                }
-            }
-            .pickerStyle(.segmented)
-            .tint(codexEffortSelectionColor)
-            .labelsHidden()
-        }
-        .padding(.vertical, 2)
-    }
-
-    @ViewBuilder
-    private func effortPickerRow(_ title: String, selection: Binding<String>, options: [String], tint: Color = AccountRowView.accent, overrideBadge: String? = nil) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
-                Text(title)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                if let badge = overrideBadge {
-                    Text(badge)
-                        .font(.system(size: 8, weight: .bold, design: .monospaced))
-                        .tracking(0.8)
-                        .foregroundColor(Color(red: 0.9, green: 0.15, blue: 0.1))
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 2)
-                        .background(
-                            RoundedRectangle(cornerRadius: 3)
-                                .stroke(Color(red: 0.9, green: 0.15, blue: 0.1).opacity(0.5), lineWidth: 1)
-                        )
-                        .opacity(1.0)
-                }
-                Spacer()
-            }
-            Picker("", selection: selection) {
-                ForEach(options, id: \.self) { option in
-                    Text(option).tag(option)
-                }
-            }
-            .pickerStyle(.segmented)
-            .tint(tint)
-            .labelsHidden()
-        }
-        .padding(.vertical, 2)
-    }
-
-    /// A collapsible variant of `effortPickerRow` that shows only the title + current
-    /// selection badge when collapsed. Tapping the header toggles the picker visibility.
-    @ViewBuilder
-    private func collapsibleEffortPickerRow(
-        _ title: String,
-        selection: Binding<String>,
-        options: [String],
-        tint: Color,
-        isExpanded: Binding<Bool>,
-        overrideBadge: String? = nil
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Button {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    isExpanded.wrappedValue.toggle()
-                }
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: isExpanded.wrappedValue ? "chevron.down" : "chevron.right")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                    Text(title)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    if let badge = overrideBadge {
-                        Text(badge)
-                            .font(.system(size: 8, weight: .bold, design: .monospaced))
-                            .tracking(0.8)
-                            .foregroundColor(Color(red: 0.9, green: 0.15, blue: 0.1))
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 2)
-                            .background(
-                                RoundedRectangle(cornerRadius: 3)
-                                    .stroke(Color(red: 0.9, green: 0.15, blue: 0.1).opacity(0.5), lineWidth: 1)
-                            )
-                    }
-                    Spacer()
-                    Text(selection.wrappedValue)
-                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
-                        .foregroundColor(tint)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(
-                            RoundedRectangle(cornerRadius: 4)
-                                .stroke(tint.opacity(0.4), lineWidth: 1)
-                        )
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(title)
-            .accessibilityValue(selection.wrappedValue)
-            .accessibilityHint(isExpanded.wrappedValue ? "Collapse effort picker" : "Expand effort picker")
-
-            if isExpanded.wrappedValue {
-                Picker("", selection: selection) {
-                    ForEach(options, id: \.self) { option in
-                        Text(option).tag(option)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .tint(tint)
-                .labelsHidden()
-            }
-        }
-        .padding(.vertical, 2)
-    }
     
     private func toggleAccountDisabled(_ account: AuthAccount) {
         if authManager.toggleAccountDisabled(account) {
@@ -1509,7 +984,7 @@ struct SettingsView: View {
               let models = json["customModels"] as? [[String: Any]] else {
             return false
         }
-        let enabledModels = DroidProxyModelCatalog.settingsModels(advanced: factoryAdvancedModels).filter { model in
+        let enabledModels = DroidProxyModelCatalog.settingsModels().filter { model in
             guard let key = DroidProxyModelCatalog.providerKey(forSettingsModel: model) else { return true }
             return serverManager.isProviderEnabled(key)
         }
@@ -1545,7 +1020,7 @@ struct SettingsView: View {
                 || id.hasPrefix("custom:CC:")
         }
 
-        let enabledModels = DroidProxyModelCatalog.settingsModels(advanced: factoryAdvancedModels).filter { model in
+        let enabledModels = DroidProxyModelCatalog.settingsModels().filter { model in
             guard let key = DroidProxyModelCatalog.providerKey(forSettingsModel: model) else { return true }
             return serverManager.isProviderEnabled(key)
         }
@@ -1566,8 +1041,7 @@ struct SettingsView: View {
             try data.write(to: url, options: .atomic)
             factoryModelsInstalled = true
             authResultSuccess = true
-            let mode = factoryAdvancedModels ? "Advanced DroidProxy model entries" : "DroidProxy models"
-            authResultMessage = "\(mode) added to Factory settings.\n\nRestart Factory (or open a new session) to see them in the model picker."
+            authResultMessage = "DroidProxy models added to Factory settings.\n\nReasoning effort is controlled from Droid CLI per session (low / medium / high / xhigh / max as supported by each model). Restart Factory or open a new session to see them in the model picker."
             showingAuthResult = true
             NSLog("[SettingsView] Factory custom models applied to %@", url.path)
         } catch {
@@ -1748,15 +1222,7 @@ struct SettingsView: View {
     }
 
     private func renderedChallengerPluginContent(_ content: String) -> String {
-        var rendered = content
-        if factoryAdvancedModels {
-            rendered = rendered
-                .replacingOccurrences(of: "model: custom:droidproxy:opus-4-7", with: "model: custom:droidproxy:opus-4-7-xhigh")
-                .replacingOccurrences(of: "model: custom:droidproxy:gpt-5.2", with: "model: custom:droidproxy:gpt-5.2-high")
-                .replacingOccurrences(of: "model: custom:droidproxy:gemini-3.1-pro", with: "model: custom:droidproxy:gemini-3.1-pro-high")
-        }
-
-        return rendered
+        content
             .split(separator: "\n", omittingEmptySubsequences: false)
             .map { line in
                 var s = String(line)

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -284,7 +284,9 @@ class ThinkingProxy {
 
         if method == "POST" && !bodyString.isEmpty {
             ThinkingProxy.fileLog("INCOMING REQUEST: \(method) \(rewrittenPath)")
-            ThinkingProxy.fileLog("ORIGINAL BODY (first 4000): \(String(bodyString.prefix(4000)))")
+            if let summary = summarizeReasoningFields(in: bodyString) {
+                ThinkingProxy.fileLog("REQUEST REASONING: \(summary)")
+            }
             if let result = processOpenAIFastMode(jsonString: modifiedBody, path: rewrittenPath) {
                 modifiedBody = result
             }
@@ -375,6 +377,53 @@ class ThinkingProxy {
     private func isResponsesAPIPath(_ path: String) -> Bool {
         let normalizedPath = path.split(separator: "?").first.map(String.init) ?? path
         return Self.responsesAPIPaths.contains(normalizedPath)
+    }
+
+    /// Extracts just the reasoning/thinking metadata from a request body so the log
+    /// shows what Droid is actually sending without us also dumping the entire prompt.
+    /// Returns nil only when the body can't be parsed.
+    private func summarizeReasoningFields(in bodyString: String) -> String? {
+        guard let data = bodyString.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        var parts: [String] = []
+        if let model = json["model"] as? String {
+            parts.append("model=\(model)")
+        }
+        let inspectedKeys = [
+            "reasoning",
+            "reasoning_effort",
+            "thinking",
+            "output_config",
+            "service_tier",
+            "generationConfig"
+        ]
+        for key in inspectedKeys {
+            guard let value = json[key] else { continue }
+            parts.append("\(key)=\(reasoningFieldDescription(value))")
+        }
+        if parts.count == 1 {
+            parts.append("<no reasoning/thinking fields>")
+        }
+        return parts.joined(separator: " ")
+    }
+
+    private func reasoningFieldDescription(_ value: Any) -> String {
+        if let dict = value as? [String: Any],
+           let data = try? JSONSerialization.data(withJSONObject: dict),
+           let str = String(data: data, encoding: .utf8) {
+            return str
+        }
+        if let arr = value as? [Any],
+           let data = try? JSONSerialization.data(withJSONObject: arr),
+           let str = String(data: data, encoding: .utf8) {
+            return str
+        }
+        if let str = value as? String {
+            return "\"\(str)\""
+        }
+        return "\(value)"
     }
 
     private func isGeminiModel(_ bodyString: String) -> Bool {

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -2,31 +2,21 @@ import Foundation
 import Network
 
 /**
- A lightweight HTTP proxy that injects reasoning settings for supported Claude and Codex GPT models.
+ A lightweight HTTP proxy that forwards Claude / Codex / Gemini / Kimi requests to the
+ local CLIProxyAPI backend. Droid CLI controls per-session reasoning effort via Factory
+ custom-model metadata, so this proxy no longer injects reasoning or thinking fields
+ into request bodies. It still:
 
- Current behavior:
- - Requests whose `model` contains `opus-4-7` receive `thinking: {"type":"adaptive","display":"summarized"}`
-   plus `output_config.effort` from `AppPreferences.opus47ThinkingEffort`
- - Requests whose `model` contains `opus-4-6` receive `thinking: {"type":"adaptive"}`
-   plus `output_config.effort` from `AppPreferences.opus46ThinkingEffort`
- - Requests whose `model` contains `opus-4-5` receive classic
-   `thinking: {"type":"enabled","budget_tokens":N}` mapped from
-   `AppPreferences.opus45ThinkingEffort` (Opus 4.5 does not support adaptive thinking).
- - Requests whose `model` contains `sonnet-4-6` receive `thinking: {"type":"adaptive"}`
-   plus `output_config.effort` from `AppPreferences.sonnet46ThinkingEffort`
- - Claude requests with thinking enabled forward an Anthropic-Beta header that omits
-   `redact-thinking-2026-02-12`, otherwise Claude emits only signed empty thinking blocks.
- - Requests whose `model` is exactly `gpt-5.3-codex` receive `reasoning: {"effort":"..."}`
-   from `AppPreferences.gpt53CodexReasoningEffort`
-- Requests whose `model` is exactly `gpt-5.2`, `gpt-5.4`, or `gpt-5.5` receive
-  `reasoning: {"effort":"..."}` from `AppPreferences.gpt52ReasoningEffort`,
-  `AppPreferences.gpt54ReasoningEffort`, or `AppPreferences.gpt55ReasoningEffort`
-- Other models are forwarded unchanged
-- Requests whose `model` is exactly `kimi-k2.6` receive `reasoning: {"effort":"..."}`
-  from `AppPreferences.k26ReasoningEffort`
+ - Rewrites the Anthropic-Beta header to drop `redact-thinking-2026-02-12` when a Claude
+   request enables thinking, so Claude emits visible thinking blocks.
+ - Injects `service_tier: "priority"` for OpenAI Responses API requests on the user-enabled
+   GPT 5.x fast-mode models (these toggles are independent of reasoning effort).
+ - Forwards Amp CLI auth/management paths to ampcode.com and normalizes the response.
+ - Rewrites Gemini `/v1/responses` to `/v1/chat/completions` since the backend does not
+   support Gemini via the Responses API endpoint.
 
-The proxy edits the raw JSON string instead of re-serializing it so cache-sensitive key
-ordering is preserved.
+ JSON edits are surgical (no re-serialization) so Anthropic prompt-cache key ordering is
+ preserved.
  */
 class ThinkingProxy {
     private var listener: NWListener?
@@ -294,12 +284,7 @@ class ThinkingProxy {
 
         if method == "POST" && !bodyString.isEmpty {
             ThinkingProxy.fileLog("INCOMING REQUEST: \(method) \(rewrittenPath)")
-            ThinkingProxy.fileLog("ORIGINAL BODY (first 500): \(String(bodyString.prefix(500)))")
-            if let transformed = processThinkingParameter(jsonString: bodyString) {
-                modifiedBody = transformed
-                ThinkingProxy.fileLog("MODIFIED BODY (first 500): \(String(modifiedBody.prefix(500)))")
-                ThinkingProxy.fileLog("THINKING INJECTED: true")
-            }
+            ThinkingProxy.fileLog("ORIGINAL BODY (first 4000): \(String(bodyString.prefix(4000)))")
             if let result = processOpenAIFastMode(jsonString: modifiedBody, path: rewrittenPath) {
                 modifiedBody = result
             }
@@ -382,329 +367,6 @@ class ThinkingProxy {
         value.split(separator: ",").map { String($0) }
     }
 
-    /**
-     Processes the JSON body to add thinking or reasoning parameters for supported models.
-     Uses surgical string operations to preserve original JSON structure and key ordering,
-     which is critical for Anthropic's prompt caching (cache_control fields must be preserved).
-     Returns tuple of (modifiedJSON, needsTransformation)
-     */
-    private func processThinkingParameter(jsonString: String) -> String? {
-        guard let jsonData = jsonString.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
-              let model = json["model"] as? String else {
-            return nil
-        }
-
-        if let variant = DroidProxyModelCatalog.advancedVariant(for: model) {
-            return processAdvancedModelVariant(jsonString: jsonString, json: json, requestedModel: model, variant: variant)
-        }
-
-        if let effort = codexReasoningEffort(for: model) {
-            var result = jsonString
-            result = injectJSONField(in: result, afterKey: "model", fieldName: "reasoning",
-                                     fieldValue: "{\"effort\":\"\(effort)\"}")
-            NSLog("[ThinkingProxy] Injected Codex reasoning for '\(model)' with effort '\(effort)'")
-            ThinkingProxy.fileLog("INJECTED Codex reasoning: effort=\(effort) for model \(model)")
-            return result
-        }
-
-        if let effort = kimiReasoningEffort(for: model) {
-            var result = jsonString
-            result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "reasoning_effort",
-                                              fieldValue: "\"\(effort)\"",
-                                              existsInJSON: json["reasoning_effort"] != nil)
-            NSLog("[ThinkingProxy] Injected Kimi reasoning_effort for '\(model)' with effort '\(effort)'")
-            ThinkingProxy.fileLog("INJECTED Kimi reasoning_effort=\(effort) for model \(model)")
-            return result
-        }
-
-        if let level = geminiThinkingLevel(for: model) {
-            var result = jsonString
-            result = injectGeminiThinkingLevel(in: result, level: level, generationConfigExists: json["generationConfig"] != nil)
-            NSLog("[ThinkingProxy] Injected Gemini thinking for '\(model)' with level '\(level)'")
-            ThinkingProxy.fileLog("INJECTED Gemini thinking: level=\(level) for model \(model)")
-            return result
-        }
-
-        // Opus 4.5 uses classic extended thinking (budget_tokens) — it does not support adaptive.
-        if isOpus45Model(model) {
-            return processOpus45ClassicThinking(jsonString: jsonString, json: json, model: model)
-        }
-
-        guard let effort = claudeAdaptiveThinkingEffort(for: model) else {
-            return nil
-        }
-
-        return processClaudeAdaptiveThinking(jsonString: jsonString, json: json, model: model, effort: effort, allowMaxBudgetMode: true)
-    }
-
-    private func processAdvancedModelVariant(jsonString: String, json: [String: Any], requestedModel: String, variant: DroidProxyModelVariant) -> String? {
-        let baseModel = variant.definition.baseModel
-        let level = variant.level.value
-        let rewrittenJSON = rewriteModelValue(in: jsonString, from: requestedModel, to: baseModel)
-
-        switch variant.definition.kind {
-        case .codex:
-            var result = rewrittenJSON
-            result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "reasoning",
-                                              fieldValue: "{\"effort\":\"\(level)\"}",
-                                              existsInJSON: json["reasoning"] != nil)
-            NSLog("[ThinkingProxy] Injected advanced Codex reasoning for '\(requestedModel)' as '\(baseModel)' with effort '\(level)'")
-            ThinkingProxy.fileLog("INJECTED advanced Codex reasoning: effort=\(level) for model \(requestedModel) -> \(baseModel)")
-            return result
-
-        case .kimi:
-            var result = rewrittenJSON
-            result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "reasoning_effort",
-                                              fieldValue: "\"\(level)\"",
-                                              existsInJSON: json["reasoning_effort"] != nil)
-            NSLog("[ThinkingProxy] Injected advanced Kimi reasoning_effort for '\(requestedModel)' as '\(baseModel)' with effort '\(level)'")
-            ThinkingProxy.fileLog("INJECTED advanced Kimi reasoning_effort=\(level) for model \(requestedModel) -> \(baseModel)")
-            return result
-
-        case .gemini:
-            var result = rewrittenJSON
-            result = injectGeminiThinkingLevel(in: result, level: level, generationConfigExists: json["generationConfig"] != nil)
-            NSLog("[ThinkingProxy] Injected advanced Gemini thinking for '\(requestedModel)' as '\(baseModel)' with level '\(level)'")
-            ThinkingProxy.fileLog("INJECTED advanced Gemini thinking: level=\(level) for model \(requestedModel) -> \(baseModel)")
-            return result
-
-        case .claudeClassic:
-            return processOpus45ClassicThinking(jsonString: rewrittenJSON, json: json, model: baseModel, effort: level)
-
-        case .claudeAdaptive:
-            return processClaudeAdaptiveThinking(jsonString: rewrittenJSON, json: json, model: baseModel, effort: level, allowMaxBudgetMode: false)
-        }
-    }
-
-    private func processClaudeAdaptiveThinking(jsonString: String, json: [String: Any], model: String, effort: String, allowMaxBudgetMode: Bool) -> String {
-        var result = jsonString
-
-        result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "stream",
-                                          fieldValue: "true", existsInJSON: json["stream"] != nil)
-
-        if allowMaxBudgetMode && AppPreferences.claudeMaxBudgetMode &&
-            (model.contains("sonnet-4-6") || model.contains("opus-4-6")) {
-            // Sonnet 4.6 / Opus 4.6 classic extended-thinking override. budget_tokens must be strictly less
-            // than max_tokens (min 1024). Request body changes stay inside the adaptive-thinking
-            // window this path already controls.
-            let maxTokens = 64000
-            let budgetTokens = maxTokens - 1
-            result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "max_tokens",
-                                              fieldValue: "\(maxTokens)",
-                                              existsInJSON: json["max_tokens"] != nil)
-            result = replaceOrInjectJSONField(in: result, afterKey: "max_tokens",
-                                              fieldName: "thinking",
-                                              fieldValue: "{\"type\":\"enabled\",\"budget_tokens\":\(budgetTokens)}",
-                                              existsInJSON: json["thinking"] != nil)
-            result = replaceOrInjectJSONField(in: result, afterKey: "thinking", fieldName: "output_config",
-                                              fieldValue: "{\"effort\":\"max\"}",
-                                              existsInJSON: json["output_config"] != nil)
-            NSLog("[ThinkingProxy] Injected classic budget_tokens max mode for '\(model)' budget=\(budgetTokens) max_tokens=\(maxTokens)")
-            ThinkingProxy.fileLog("INJECTED classic budget_tokens max mode: budget_tokens=\(budgetTokens) max_tokens=\(maxTokens) for model \(model)")
-        } else {
-            let thinkingValue = isOpus47Model(model)
-                ? "{\"type\":\"adaptive\",\"display\":\"summarized\"}"
-                : "{\"type\":\"adaptive\"}"
-            result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "thinking",
-                                              fieldValue: thinkingValue,
-                                              existsInJSON: json["thinking"] != nil)
-            result = replaceOrInjectJSONField(in: result, afterKey: "thinking", fieldName: "output_config",
-                                              fieldValue: "{\"effort\":\"\(effort)\"}",
-                                              existsInJSON: json["output_config"] != nil)
-            NSLog("[ThinkingProxy] Injected adaptive thinking for '\(model)' with effort '\(effort)'")
-            ThinkingProxy.fileLog("INJECTED adaptive thinking: effort=\(effort) for model \(model)")
-        }
-
-        return result
-    }
-
-    private func codexReasoningEffort(for model: String) -> String? {
-        switch model {
-        case "gpt-5.2":
-            return AppPreferences.gpt52ReasoningEffort
-        case "gpt-5.3-codex":
-            return AppPreferences.gpt53CodexReasoningEffort
-        case "gpt-5.4":
-            return AppPreferences.gpt54ReasoningEffort
-        case "gpt-5.5":
-            return AppPreferences.gpt55ReasoningEffort
-        default:
-            return nil
-        }
-    }
-
-    private func kimiReasoningEffort(for model: String) -> String? {
-        if model == "kimi-k2.6" {
-            return AppPreferences.k26ReasoningEnabled ? "high" : nil
-        }
-        return nil
-    }
-
-    /// Replaces an existing JSON field's value or injects it if missing.
-    private func replaceOrInjectJSONField(in json: String, afterKey: String, fieldName: String, fieldValue: String, existsInJSON: Bool) -> String {
-        if existsInJSON {
-            return replaceJSONFieldValue(in: json, fieldName: fieldName, newValue: fieldValue)
-        }
-        return injectJSONField(in: json, afterKey: afterKey, fieldName: fieldName, fieldValue: fieldValue)
-    }
-
-    private func injectGeminiThinkingLevel(in json: String, level: String, generationConfigExists: Bool) -> String {
-        let generationConfigValue = "{\"thinkingConfig\":{\"thinking_level\":\"\(level)\"}}"
-        guard generationConfigExists else {
-            return injectJSONField(in: json, afterKey: "model", fieldName: "generationConfig", fieldValue: generationConfigValue)
-        }
-
-        guard let generationConfigLocation = findTopLevelFieldLocation(in: json, key: "generationConfig") else {
-            NSLog("[ThinkingProxy] Warning: Could not find generationConfig for Gemini thinking merge")
-            return json
-        }
-
-        let generationConfig = String(json[generationConfigLocation.valueRange])
-        guard let updatedGenerationConfig = upsertGeminiThinkingLevel(inGenerationConfig: generationConfig, level: level) else {
-            return replaceJSONFieldValue(in: json, fieldName: "generationConfig", newValue: generationConfigValue)
-        }
-
-        var result = json
-        result.replaceSubrange(generationConfigLocation.valueRange, with: updatedGenerationConfig)
-        return result
-    }
-
-    private func upsertGeminiThinkingLevel(inGenerationConfig generationConfig: String, level: String) -> String? {
-        let thinkingConfigValue = "{\"thinking_level\":\"\(level)\"}"
-        guard let thinkingConfigLocation = findTopLevelFieldLocation(in: generationConfig, key: "thinkingConfig") else {
-            return upsertJSONField(inObject: generationConfig, fieldName: "thinkingConfig", fieldValue: thinkingConfigValue)
-        }
-
-        let thinkingConfig = String(generationConfig[thinkingConfigLocation.valueRange])
-        let updatedThinkingConfig = upsertJSONField(inObject: thinkingConfig,
-                                                    fieldName: "thinking_level",
-                                                    fieldValue: "\"\(level)\"") ?? thinkingConfigValue
-
-        var result = generationConfig
-        result.replaceSubrange(thinkingConfigLocation.valueRange, with: updatedThinkingConfig)
-        return result
-    }
-
-    private func upsertJSONField(inObject object: String, fieldName: String, fieldValue: String) -> String? {
-        guard let objectStart = firstNonWhitespaceIndex(in: object, from: object.startIndex),
-              object[objectStart] == "{",
-              let objectEnd = lastNonWhitespaceIndex(in: object),
-              object[objectEnd] == "}" else {
-            return nil
-        }
-
-        if let location = findTopLevelFieldLocation(in: object, key: fieldName) {
-            var result = object
-            result.replaceSubrange(location.valueRange, with: fieldValue)
-            return result
-        }
-
-        var result = object
-        let contentStart = object.index(after: objectStart)
-        let isEmptyObject = firstNonWhitespaceIndex(in: object, from: contentStart) == objectEnd
-        result.insert(contentsOf: "\(isEmptyObject ? "" : ",")\"\(fieldName)\":\(fieldValue)", at: objectEnd)
-        return result
-    }
-
-    /// Replaces the value of an existing top-level JSON field.
-    private func replaceJSONFieldValue(in json: String, fieldName: String, newValue: String) -> String {
-        guard let location = findTopLevelFieldLocation(in: json, key: fieldName) else {
-            NSLog("[ThinkingProxy] Warning: Could not find key '\(fieldName)' for value replacement")
-            return json
-        }
-
-        var result = json
-        result.replaceSubrange(location.valueRange, with: newValue)
-        return result
-    }
-
-    private func claudeAdaptiveThinkingEffort(for model: String) -> String? {
-        guard model.starts(with: "claude-") || model.starts(with: "gemini-claude-") else {
-            return nil
-        }
-
-        if model.contains("opus-4-7") {
-            return AppPreferences.opus47ThinkingEffort
-        }
-        if model.contains("opus-4-6") {
-            return AppPreferences.opus46ThinkingEffort
-        }
-        if model.contains("sonnet-4-6") {
-            return AppPreferences.sonnet46ThinkingEffort
-        }
-        return nil
-    }
-
-    private func isOpus47Model(_ model: String) -> Bool {
-        model.contains("opus-4-7")
-    }
-
-    /// Matches Opus 4.5 (`claude-opus-4-5`, `gemini-claude-opus-4-5`, date-suffixed variants)
-    /// without also matching Opus 4.5x variants like `opus-4-50` or `opus-4-5x`.
-    /// The `opus-4-5` token must be at the end of the string or followed by a `-` delimiter.
-    private func isOpus45Model(_ model: String) -> Bool {
-        guard model.starts(with: "claude-") || model.starts(with: "gemini-claude-") else {
-            return false
-        }
-        guard let range = model.range(of: "opus-4-5") else {
-            return false
-        }
-        let suffix = model[range.upperBound...]
-        return suffix.isEmpty || suffix.hasPrefix("-")
-    }
-
-    /// Opus 4.5 does not accept adaptive thinking. It requires the legacy
-    /// `thinking: {type: "enabled", budget_tokens: N}` shape, where
-    /// `budget_tokens < max_tokens` (min 1024).
-    private func processOpus45ClassicThinking(jsonString: String, json: [String: Any], model: String, effort: String = AppPreferences.opus45ThinkingEffort) -> String? {
-        let (budgetTokens, maxTokens) = opus45ClassicBudget(for: effort)
-
-        var result = jsonString
-
-        result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "stream",
-                                          fieldValue: "true", existsInJSON: json["stream"] != nil)
-        result = replaceOrInjectJSONField(in: result, afterKey: "model", fieldName: "max_tokens",
-                                          fieldValue: "\(maxTokens)",
-                                          existsInJSON: json["max_tokens"] != nil)
-        result = replaceOrInjectJSONField(in: result, afterKey: "max_tokens",
-                                          fieldName: "thinking",
-                                          fieldValue: "{\"type\":\"enabled\",\"budget_tokens\":\(budgetTokens)}",
-                                          existsInJSON: json["thinking"] != nil)
-
-        NSLog("[ThinkingProxy] Injected Opus 4.5 classic thinking for '\(model)' effort=\(effort) budget_tokens=\(budgetTokens) max_tokens=\(maxTokens)")
-        ThinkingProxy.fileLog("INJECTED Opus 4.5 classic thinking: effort=\(effort) budget_tokens=\(budgetTokens) max_tokens=\(maxTokens) for model \(model)")
-        return result
-    }
-
-    /// Maps effort levels to (budget_tokens, max_tokens) pairs for Opus 4.5.
-    /// Opus 4.5 supports `max_tokens` up to 64000 and requires budget_tokens < max_tokens.
-    private func opus45ClassicBudget(for effort: String) -> (Int, Int) {
-        switch effort {
-        case "low":
-            return (4000, 16000)
-        case "medium":
-            return (16000, 32000)
-        case "high":
-            return (32000, 48000)
-        case "max":
-            return (48000, 64000)
-        default:
-            return (32000, 48000)
-        }
-    }
-
-    private func geminiThinkingLevel(for model: String) -> String? {
-        switch model {
-        case "gemini-3.1-pro-preview":
-            return AppPreferences.gemini31ProThinkingLevel
-        case "gemini-3-flash-preview":
-            return AppPreferences.gemini3FlashThinkingLevel
-        default:
-            return nil
-        }
-    }
-
     private static let responsesAPIPaths: Set<String> = [
         "/v1/responses",
         "/api/v1/responses"
@@ -722,21 +384,6 @@ class ThinkingProxy {
             return false
         }
         return model.hasPrefix("gemini-")
-    }
-
-    private func rewriteModelValue(in json: String, from oldModel: String, to newModel: String) -> String {
-        let escaped = NSRegularExpression.escapedPattern(for: oldModel)
-        let pattern = "(\"model\"\\s*:\\s*\")\(escaped)(\")"
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: json, range: NSRange(json.startIndex..., in: json)),
-              let matchRange = Range(match.range, in: json) else {
-            NSLog("[ThinkingProxy] Warning: Could not find model value '\(oldModel)' for rewrite")
-            return json
-        }
-        var result = json
-        let replacement = "\"model\":\"\(newModel)\""
-        result.replaceSubrange(matchRange, with: replacement)
-        return result
     }
 
     // MARK: - Surgical JSON string helpers
@@ -824,17 +471,6 @@ class ThinkingProxy {
             index = json.index(after: index)
         }
         return index < json.endIndex ? index : nil
-    }
-
-    private func lastNonWhitespaceIndex(in json: String) -> String.Index? {
-        var index = json.endIndex
-        while index > json.startIndex {
-            index = json.index(before: index)
-            if !json[index].isWhitespace {
-                return index
-            }
-        }
-        return nil
     }
 
     private func parseJSONStringToken(in json: String, startingAt startQuote: String.Index) -> (String, String.Index)? {


### PR DESCRIPTION
## Summary

Droid CLI now ships its own per-session reasoning selector for custom models, so DroidProxy no longer needs to expose any thinking UI of its own. This PR rips out every effort picker, max-budget mode, advanced per-level model entries, and the matching ThinkingProxy injection paths. Factory custom models still get applied, but the entries now carry native reasoning metadata (`enableThinking`, `supportedReasoningEfforts`, `defaultReasoningEffort`, `reasoningEffort`) so Droid's UI exposes the full level set for each model:

| Model | Levels |
|---|---|
| Opus 4.7 | low, medium, high, xhigh, max |
| Opus 4.6 / 4.5 / Sonnet 4.6 | low, medium, high, max |
| GPT 5.2 / 5.3 Codex / 5.4 / 5.5 | low, medium, high, xhigh |
| Gemini 3.1 Pro | low, medium, high |
| Gemini 3 Flash | minimal, low, medium, high |
| Kimi K2.6 | high (single level) |

Inspired by stale PR #56, but built fresh off `main` since the diff there had drifted and only covered Codex.

## What changed

- **`AppPreferences.swift`** – Removed every effort/level key + their defaults (Opus 4.7/4.6/4.5, Sonnet 4.6, GPT 5.x reasoning, Gemini 3.1 Pro, Gemini 3 Flash, Kimi K2.6, Claude Max Budget Mode, factoryAdvancedModels). Kept the Codex fast-mode (`service_tier=priority`) toggles since those are API-priority, not thinking.
- **`DroidProxyModelCatalog.swift`** – Dropped the `advanced`-mode plumbing (per-level entries, `advancedVariant`, `DroidProxyModelVariant`). Each definition now carries a `defaultLevelValue`, and `settingsEntry` always embeds the native reasoning fields when the model has more than one level.
- **`SettingsView.swift`** – Deleted `MaxBudgetToggleView`, `HazardStripesView`, `advancedFactoryModelsNotice`, `effortPickerRow`, `collapsibleEffortPickerRow`, `codexReasoningEffortRow`, the Claude/Gemini Model Settings sub-sections, the Kimi reasoning toggle, the Advanced Factory models checkbox, and the Max Budget warning alert. The Codex section now only surfaces the per-model fast-mode toggles.
- **`ThinkingProxy.swift`** – Removed `processThinkingParameter` and every helper it called (Codex reasoning, Kimi reasoning_effort, Gemini thinkingConfig, Claude adaptive thinking, Opus 4.5 classic thinking, max budget override, advanced variant handling). Kept the visible-thinking Anthropic-Beta header rewrite (needed for Claude streaming) and `processOpenAIFastMode` (independent of reasoning). Added a focused `REQUEST REASONING:` log line that extracts only the reasoning / thinking / output_config / service_tier / generationConfig fields from the parsed body, so verifying what Droid CLI sends doesn't require dumping the whole prompt.
- **`AGENTS.md`** – Rewrote the ThinkingProxy section and the Key Files entries to match the post-refactor reality.

Net diff (source files): **+109 / -1166 lines.**

## How to test

1. `cd src && swift build -c debug` ✅
2. `./create-app-bundle.sh && open DroidProxy.app`
3. Open Settings — Claude/Gemini/Kimi rows have no thinking selectors; Codex still has a Fast Mode subsection with the four `service_tier` toggles.
4. Click **Apply** under Factory custom models, then open `~/.factory/settings.json` and confirm each DroidProxy entry has `enableThinking: true`, `supportedReasoningEfforts: [...]`, `defaultReasoningEffort`, and `reasoningEffort`.
5. Restart a Droid CLI session, pick a custom DroidProxy model, and verify the per-session reasoning selector shows every level for that model.
6. Fire a request and `tail -f /tmp/droidproxy-debug.log` — you should see clean `REQUEST REASONING:` lines and no `INJECTED adaptive thinking` / `INJECTED Codex reasoning` / etc.

## Live verification

Confirmed end-to-end against the running app:

```
REQUEST REASONING: model=gpt-5.5    reasoning={"effort":"xhigh","summary":"auto"}
REQUEST REASONING: model=gpt-5.5    reasoning={"effort":"low","summary":"auto"}
REQUEST REASONING: model=gpt-5.5    reasoning={"effort":"medium","summary":"auto"}
REQUEST REASONING: model=claude-opus-4-7 thinking={"display":"summarized","type":"adaptive"} output_config={"effort":"medium"}
REQUEST REASONING: model=claude-opus-4-7 thinking={"display":"summarized","type":"adaptive"} output_config={"effort":"max"}
```

Droid CLI is sending OpenAI-Responses-style `reasoning: {effort, summary}` for Codex models and Anthropic-style `thinking: {type:"adaptive", display:"summarized"} + output_config: {effort}` for Claude models — exactly the shapes the proxy used to inject — and the values change per session, proving the CLI selector is now driving things.

## Notes

- The challenger plugin droids still reference the simple `custom:droidproxy:opus-4-7` / `gpt-5.2` / `gemini-3.1-pro` IDs, which now expose the native reasoning selector by default. No changes needed to those droid files.