### PR TITLE
Fix Factory custom models for Droid 0.133

### DIFF
--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -40,8 +40,9 @@ struct DroidProxyModelDefinition: Equatable {
         }
     }
 
-    /// Settings entry that embeds Factory's native reasoning metadata so Droid's
-    /// per-session reasoning selector picks up the supported levels for this model.
+    /// Settings entry for Factory's custom model schema. Droid 0.133 accepts a
+    /// single default `reasoningEffort` here; it derives selectable levels from
+    /// known base model IDs when it can.
     var settingsEntry: [String: Any] {
         var entry: [String: Any] = [
             "model": baseModel,
@@ -55,9 +56,7 @@ struct DroidProxyModelDefinition: Equatable {
         ]
         guard !levels.isEmpty else { return entry }
         entry["enableThinking"] = true
-        entry["supportedReasoningEfforts"] = levels.map(\.value)
         let defLevel = levels.count == 1 ? levels[0].value : defaultLevelValue
-        entry["defaultReasoningEffort"] = defLevel
         entry["reasoningEffort"] = defLevel
         return entry
     }
@@ -262,30 +261,6 @@ enum DroidProxyModelCatalog {
                 maxOutputTokens: 32768,
                 levels: antigravityMediumLevel,
                 defaultLevelValue: "medium"
-            ),
-            DroidProxyModelDefinition(
-                baseModel: "gemini-3.1-pro-preview",
-                idSlug: "gemini-3.1-pro",
-                displayName: "Gemini 3.1 Pro",
-                maxOutputTokens: 65536,
-                provider: "google",
-                providerKey: "gemini",
-                baseURL: "http://localhost:8317",
-                kind: .gemini,
-                levels: geminiProLevels,
-                defaultLevelValue: "high"
-            ),
-            DroidProxyModelDefinition(
-                baseModel: "gemini-3-flash-preview",
-                idSlug: "gemini-3-flash",
-                displayName: "Gemini 3 Flash",
-                maxOutputTokens: 65536,
-                provider: "google",
-                providerKey: "gemini",
-                baseURL: "http://localhost:8317",
-                kind: .gemini,
-                levels: geminiFlashLevels,
-                defaultLevelValue: "high"
             ),
             DroidProxyModelDefinition(
                 baseModel: "kimi-k2.6",

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -603,7 +603,7 @@ struct SettingsView: View {
                             .controlSize(.small)
                         }
 
-                        Text("Apply writes DroidProxy model aliases into ~/.factory/settings.json. Each model exposes its full reasoning level set (low/medium/high/xhigh/max) directly in Factory's per-session selector — pick the level from Droid CLI, not here.")
+                        Text("Apply writes DroidProxy model aliases into ~/.factory/settings.json and makes a timestamped backup first. Reasoning effort is selected from Droid CLI when the model exposes multiple levels.")
                             .font(.caption2)
                             .foregroundColor(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
@@ -1229,6 +1229,8 @@ struct SettingsView: View {
         settings["customModels"] = models
 
         do {
+            backupFactorySettingsIfPresent(url)
+
             var data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
             if var jsonString = String(data: data, encoding: .utf8) {
                 jsonString = jsonString.replacingOccurrences(of: "\\/", with: "/")
@@ -1237,7 +1239,7 @@ struct SettingsView: View {
             try data.write(to: url, options: .atomic)
             factoryModelsInstalled = true
             authResultSuccess = true
-            authResultMessage = "DroidProxy models added to Factory settings.\n\nReasoning effort is controlled from Droid CLI per session (low / medium / high / xhigh / max as supported by each model). Restart Factory or open a new session to see them in the model picker."
+            authResultMessage = "DroidProxy models added to Factory settings.\n\nA timestamped backup was saved next to settings.json before writing. Reasoning effort is controlled from Droid CLI per session when the selected model exposes multiple levels. Restart Factory or open a new session to see them in the model picker."
             showingAuthResult = true
             NSLog("[SettingsView] Factory custom models applied to %@", url.path)
         } catch {
@@ -1245,6 +1247,25 @@ struct SettingsView: View {
             authResultMessage = "Failed to update Factory settings: \(error.localizedDescription)"
             showingAuthResult = true
             NSLog("[SettingsView] Failed to apply Factory custom models: %@", error.localizedDescription)
+        }
+    }
+
+    private func backupFactorySettingsIfPresent(_ url: URL) {
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone.current
+
+        let backupURL = url.deletingLastPathComponent()
+            .appendingPathComponent("settings.json.droidproxy-\(formatter.string(from: Date())).bak")
+
+        do {
+            try FileManager.default.copyItem(at: url, to: backupURL)
+            NSLog("[SettingsView] Backed up Factory settings to %@", backupURL.path)
+        } catch {
+            NSLog("[SettingsView] Failed to back up Factory settings before applying custom models: %@", error.localizedDescription)
         }
     }
 


### PR DESCRIPTION
## Summary
- remove custom model fields Droid 0.133 no longer accepts (`supportedReasoningEfforts`, `defaultReasoningEffort`)
- drop the Gemini OAuth custom model entries that used the now-unsupported `google` provider
- create a timestamped backup before writing `~/.factory/settings.json` from the Apply button

## Testing
- `cd src && swift build`
- `./dev-relaunch.sh`