### PR TITLE
Simplify Swift sources via simplify-swarm pass

### DIFF
--- a/src/Sources/AppDelegate.swift
+++ b/src/Sources/AppDelegate.swift
@@ -11,10 +11,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
     var serverManager: ServerManager!
     var thinkingProxy: ThinkingProxy!
     private let notificationCenter = UNUserNotificationCenter.current()
-    private var notificationPermissionGranted = false
     private let updaterController: SPUStandardUpdaterController
     private var authDirectoryMonitor: AuthDirectoryMonitor?
     private var themeObserver: NSObjectProtocol?
+
+    private static let menuBarIconSize = NSSize(width: 18, height: 18)
+
+    // Menu item tags used by `updateMenuBarStatus` to look up entries again.
+    private enum MenuTag {
+        static let startStop = 100
+        static let copyURL = 102
+        static let dashboard = 103
+    }
     
     override init() {
         self.updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
@@ -61,35 +69,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
     }
     
     private func preloadIcons() {
-        let statusIconSize = NSSize(width: 18, height: 18)
         let serviceIconSize = NSSize(width: 20, height: 20)
-        
-        let iconsToPreload = [
-            ("icon-active.png", statusIconSize),
-            ("icon-inactive.png", statusIconSize),
+        let iconsToPreload: [(name: String, size: NSSize)] = [
+            ("icon-active.png", Self.menuBarIconSize),
+            ("icon-inactive.png", Self.menuBarIconSize),
             ("icon-claude.png", serviceIconSize),
             ("icon-codex.png", serviceIconSize),
             ("icon-gemini.png", serviceIconSize)
         ]
-        
-        for (name, size) in iconsToPreload {
-            if IconCatalog.shared.image(named: name, resizedTo: size, template: true) == nil {
-                NSLog("[IconPreload] Warning: Failed to preload icon '%@'", name)
-            }
+
+        for (name, size) in iconsToPreload where IconCatalog.shared.image(named: name, resizedTo: size, template: true) == nil {
+            NSLog("[IconPreload] Warning: Failed to preload icon '%@'", name)
         }
     }
     
     private func configureNotifications() {
         notificationCenter.delegate = self
-        notificationCenter.requestAuthorization(options: [.alert, .sound]) { [weak self] granted, error in
+        notificationCenter.requestAuthorization(options: [.alert, .sound]) { granted, error in
             if let error = error {
                 NSLog("[Notifications] Authorization failed: %@", error.localizedDescription)
             }
-            DispatchQueue.main.async {
-                self?.notificationPermissionGranted = granted
-                if !granted {
-                    NSLog("[Notifications] Authorization not granted; notifications will be suppressed")
-                }
+            if !granted {
+                NSLog("[Notifications] Authorization not granted; notifications will be suppressed")
             }
         }
     }
@@ -124,63 +125,62 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
     
     func setupMenuBar() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-
-        if let button = statusItem.button {
-            if let icon = IconCatalog.shared.image(named: "icon-inactive.png", resizedTo: NSSize(width: 18, height: 18), template: true) {
-                button.image = icon
-            } else {
-                let fallback = NSImage(systemSymbolName: "network.slash", accessibilityDescription: "DroidProxy")
-                fallback?.isTemplate = true
-                button.image = fallback
-                NSLog("[MenuBar] Failed to load inactive icon from bundle; using fallback system icon")
-            }
-        }
+        updateStatusBarIcon(isRunning: false)
 
         menu = NSMenu()
-
-        // Server Status
         menu.addItem(NSMenuItem(title: "Server: Stopped", action: nil, keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
 
-        // Main Actions
         menu.addItem(NSMenuItem(title: "Open Settings", action: #selector(openSettings), keyEquivalent: "s"))
         menu.addItem(NSMenuItem.separator())
-        
-        // Server Control
+
         let startStopItem = NSMenuItem(title: "Start Server", action: #selector(toggleServer), keyEquivalent: "")
-        startStopItem.tag = 100
+        startStopItem.tag = MenuTag.startStop
         menu.addItem(startStopItem)
 
         menu.addItem(NSMenuItem.separator())
 
-        // Copy URL
         let copyURLItem = NSMenuItem(title: "Copy Server URL", action: #selector(copyServerURL), keyEquivalent: "c")
         copyURLItem.isEnabled = false
-        copyURLItem.tag = 102
+        copyURLItem.tag = MenuTag.copyURL
         menu.addItem(copyURLItem)
 
-        // Open Dashboard
         let dashboardItem = NSMenuItem(title: "Open Dashboard", action: #selector(openDashboard), keyEquivalent: "d")
         dashboardItem.isEnabled = false
-        dashboardItem.tag = 103
+        dashboardItem.tag = MenuTag.dashboard
         menu.addItem(dashboardItem)
 
         menu.addItem(NSMenuItem.separator())
 
-        // Check for Updates
         let checkForUpdatesItem = NSMenuItem(title: "Check for Updates...", action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)), keyEquivalent: "u")
         checkForUpdatesItem.target = updaterController
         menu.addItem(checkForUpdatesItem)
 
         menu.addItem(NSMenuItem.separator())
-
-        // Quit
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
 
         statusItem.menu = menu
     }
 
+    /// Updates the menu-bar icon to reflect the current running state, falling
+    /// back to system symbols when bundled assets are unavailable.
+    private func updateStatusBarIcon(isRunning: Bool) {
+        guard let button = statusItem?.button else { return }
+        let iconName = isRunning ? "icon-active.png" : "icon-inactive.png"
+        let stateLabel = isRunning ? "active" : "inactive"
 
+        if let icon = IconCatalog.shared.image(named: iconName, resizedTo: Self.menuBarIconSize, template: true) {
+            button.image = icon
+            return
+        }
+
+        let fallbackSymbol = isRunning ? "network" : "network.slash"
+        let accessibilityLabel = isRunning ? "Running" : "Stopped"
+        let fallback = NSImage(systemSymbolName: fallbackSymbol, accessibilityDescription: accessibilityLabel)
+        fallback?.isTemplate = true
+        button.image = fallback
+        NSLog("[MenuBar] Failed to load %@ icon; using fallback", stateLabel)
+    }
 
     @objc func openSettings() {
         if settingsWindow == nil {
@@ -230,20 +230,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
     }
     
     private func applyTheme(to window: NSWindow) {
-        let opacity = AppPreferences.backgroundOpacity
-        if opacity >= 1.0 {
-            // Fully opaque: make the window a solid NSWindow so macOS doesn't
-            // composite the desktop behind it regardless of SwiftUI layers.
-            window.isOpaque = true
-            window.backgroundColor = .black
-            window.alphaValue = 1.0
-        } else {
-            // Translucent: keep non-opaque so VisualEffectBlur can show the
-            // desktop blur. SwiftUI layers control the visible opacity.
-            window.isOpaque = false
-            window.backgroundColor = .clear
-            window.alphaValue = 1.0
-        }
+        // Fully opaque: solid NSWindow so macOS doesn't composite the desktop
+        // behind it regardless of SwiftUI layers.
+        // Translucent: keep non-opaque so VisualEffectBlur can show the desktop
+        // blur; SwiftUI layers control the visible opacity.
+        let isOpaque = AppPreferences.backgroundOpacity >= 1.0
+        window.isOpaque = isOpaque
+        window.backgroundColor = isOpaque ? .black : .clear
+        window.alphaValue = 1.0
     }
 
     @objc func toggleServer() {
@@ -300,13 +294,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
     }
 
     func stopServer() {
-        // Stop the thinking proxy first to stop accepting new requests
+        // Stop the thinking proxy first to stop accepting new requests,
+        // then shut down the CLIProxyAPI backend.
         thinkingProxy.stop()
-        
-        // Then stop CLIProxyAPI backend
         serverManager.stop()
-        
         updateMenuBarStatus()
+    }
+
+    /// Shut down both local servers if the backend is currently running. Safe
+    /// to call from termination paths where state may already be torn down.
+    private func stopServersIfRunning() {
+        guard serverManager.isRunning else { return }
+        thinkingProxy.stop()
+        serverManager.stop()
     }
 
     @objc func copyServerURL() {
@@ -324,47 +324,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
 
     @objc func handleAuthDirectoryChanged() {
         NSLog("[AppDelegate] Auth directory changed notification received — refreshing settings")
-        // Re-open settings window if it exists so the user sees the new account
-        if let window = settingsWindow {
-            window.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
-        }
+        // Re-open the settings window if it's already onscreen so the user sees
+        // the newly-discovered account.
+        guard let window = settingsWindow else { return }
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     @objc func updateMenuBarStatus() {
-        // Update status items
+        let isRunning = serverManager.isRunning
+
         if let serverStatus = menu.item(at: 0) {
-            serverStatus.title = serverManager.isRunning ? "Server: Running (port \(thinkingProxy.proxyPort))" : "Server: Stopped"
+            serverStatus.title = isRunning ? "Server: Running (port \(thinkingProxy.proxyPort))" : "Server: Stopped"
         }
+        menu.item(withTag: MenuTag.startStop)?.title = isRunning ? "Stop Server" : "Start Server"
+        menu.item(withTag: MenuTag.copyURL)?.isEnabled = isRunning
+        menu.item(withTag: MenuTag.dashboard)?.isEnabled = isRunning
 
-        // Update button states
-        if let startStopItem = menu.item(withTag: 100) {
-            startStopItem.title = serverManager.isRunning ? "Stop Server" : "Start Server"
-        }
-
-        if let copyURLItem = menu.item(withTag: 102) {
-            copyURLItem.isEnabled = serverManager.isRunning
-        }
-
-        if let dashboardItem = menu.item(withTag: 103) {
-            dashboardItem.isEnabled = serverManager.isRunning
-        }
-
-        // Update icon based on server status
-        if let button = statusItem.button {
-            let iconName = serverManager.isRunning ? "icon-active.png" : "icon-inactive.png"
-            let fallbackSymbol = serverManager.isRunning ? "network" : "network.slash"
-            
-            if let icon = IconCatalog.shared.image(named: iconName, resizedTo: NSSize(width: 18, height: 18), template: true) {
-                button.image = icon
-                NSLog("[MenuBar] Loaded %@ icon from cache", serverManager.isRunning ? "active" : "inactive")
-            } else {
-                let fallback = NSImage(systemSymbolName: fallbackSymbol, accessibilityDescription: serverManager.isRunning ? "Running" : "Stopped")
-                fallback?.isTemplate = true
-                button.image = fallback
-                NSLog("[MenuBar] Failed to load %@ icon; using fallback", serverManager.isRunning ? "active" : "inactive")
-            }
-        }
+        updateStatusBarIcon(isRunning: isRunning)
     }
 
     func showNotification(title: String, body: String) {
@@ -387,12 +364,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
     }
 
     @objc func quit() {
-        // Stop server and wait for cleanup before quitting
-        if serverManager.isRunning {
-            thinkingProxy.stop()
-            serverManager.stop()
-        }
-        // Give a moment for cleanup to complete
+        // Stop servers and give cleanup a moment before actually terminating.
+        stopServersIfRunning()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             NSApp.terminate(nil)
         }
@@ -401,28 +374,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
     func applicationWillTerminate(_ notification: Notification) {
         NotificationCenter.default.removeObserver(self, name: .serverStatusChanged, object: nil)
         NotificationCenter.default.removeObserver(self, name: .authDirectoryChanged, object: nil)
-        if let themeObserver {
-            NotificationCenter.default.removeObserver(themeObserver)
-            self.themeObserver = nil
-        }
+        removeThemeObserver()
         authDirectoryMonitor?.stop()
         authDirectoryMonitor = nil
-        // Final cleanup - stop server if still running
-        if serverManager.isRunning {
-            thinkingProxy.stop()
-            serverManager.stop()
-        }
+        stopServersIfRunning()
     }
-    
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        // If server is running, stop it first
-        if serverManager.isRunning {
-            thinkingProxy.stop()
-            serverManager.stop()
-            // Give server time to stop (up to 3 seconds total with the improved stop method)
-            return .terminateNow
-        }
+        stopServersIfRunning()
         return .terminateNow
+    }
+
+    private func removeThemeObserver() {
+        guard let themeObserver else { return }
+        NotificationCenter.default.removeObserver(themeObserver)
+        self.themeObserver = nil
     }
     
     // MARK: - Auth Directory Monitoring
@@ -447,12 +413,8 @@ extension Notification.Name {
 
 extension AppDelegate {
     func windowDidClose(_ notification: Notification) {
-        if notification.object as? NSWindow === settingsWindow {
-            if let themeObserver {
-                NotificationCenter.default.removeObserver(themeObserver)
-                self.themeObserver = nil
-            }
-            settingsWindow = nil
-        }
+        guard notification.object as? NSWindow === settingsWindow else { return }
+        removeThemeObserver()
+        settingsWindow = nil
     }
 }

--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -38,11 +38,7 @@ enum AppPreferences {
     }
 
     static var secretKey: String {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: secretKeyKey) != nil else {
-            return defaultSecretKey
-        }
-        return defaults.string(forKey: secretKeyKey) ?? defaultSecretKey
+        UserDefaults.standard.string(forKey: secretKeyKey) ?? defaultSecretKey
     }
 
     static var backgroundOpacity: Double {

--- a/src/Sources/AuthDirectoryMonitor.swift
+++ b/src/Sources/AuthDirectoryMonitor.swift
@@ -32,21 +32,8 @@ final class AuthDirectoryMonitor {
             queue: DispatchQueue.main
         )
 
-        source.setEventHandler { [weak self] in
-            guard let self else { return }
-            pendingRefresh?.cancel()
-            let workItem = DispatchWorkItem { [weak self] in
-                guard let self else { return }
-                NSLog("%@ Auth directory changed", logPrefix)
-                onChange()
-            }
-            pendingRefresh = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + debounceInterval, execute: workItem)
-        }
-
-        source.setCancelHandler {
-            close(fileDescriptor)
-        }
+        source.setEventHandler { [weak self] in self?.scheduleRefresh() }
+        source.setCancelHandler { close(fileDescriptor) }
 
         source.resume()
         self.source = source
@@ -57,5 +44,16 @@ final class AuthDirectoryMonitor {
         pendingRefresh = nil
         source?.cancel()
         source = nil
+    }
+
+    private func scheduleRefresh() {
+        pendingRefresh?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            NSLog("%@ Auth directory changed", logPrefix)
+            onChange()
+        }
+        pendingRefresh = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + debounceInterval, execute: workItem)
     }
 }

--- a/src/Sources/AuthStatus.swift
+++ b/src/Sources/AuthStatus.swift
@@ -23,7 +23,7 @@ enum ServiceType: String, CaseIterable {
             return nil
         }
     }
-    
+
     var displayName: String {
         switch self {
         case .claude: return "Claude Code"
@@ -44,22 +44,18 @@ struct AuthAccount: Identifiable, Equatable {
     let expired: Date?
     let filePath: URL
     let isDisabled: Bool
-    
+
     var isExpired: Bool {
-        guard let expired = expired else { return false }
+        guard let expired else { return false }
         return expired < Date()
     }
-    
+
     var displayName: String {
-        if let email = email, !email.isEmpty {
-            return email
-        }
-        if let login = login, !login.isEmpty {
-            return login
-        }
+        if let email, !email.isEmpty { return email }
+        if let login, !login.isEmpty { return login }
         return id
     }
-    
+
     static func == (lhs: AuthAccount, rhs: AuthAccount) -> Bool {
         lhs.id == rhs.id
     }
@@ -69,13 +65,13 @@ struct AuthAccount: Identifiable, Equatable {
 struct ServiceAccounts {
     var type: ServiceType
     var accounts: [AuthAccount] = []
-    
+
     var hasAccounts: Bool { !accounts.isEmpty }
 }
 
 class AuthManager: ObservableObject {
-    @Published var serviceAccounts: [ServiceType: ServiceAccounts] = [:]
-    
+    @Published var serviceAccounts: [ServiceType: ServiceAccounts] = AuthManager.emptyAccounts()
+
     private static let dateFormatters: [ISO8601DateFormatter] = {
         let withFractional = ISO8601DateFormatter()
         withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -83,94 +79,41 @@ class AuthManager: ObservableObject {
         standard.formatOptions = [.withInternetDateTime]
         return [withFractional, standard]
     }()
-    
-    init() {
-        // Initialize empty accounts for all service types
-        for type in ServiceType.allCases {
-            serviceAccounts[type] = ServiceAccounts(type: type)
-        }
-    }
-    
+
     func accounts(for type: ServiceType) -> [AuthAccount] {
         serviceAccounts[type]?.accounts ?? []
     }
-    
+
     func hasAccounts(for type: ServiceType) -> Bool {
         serviceAccounts[type]?.hasAccounts ?? false
     }
-    
+
     func checkAuthStatus() {
         let authDir = AuthPaths.authDirectory
-        
-        // Build new accounts dictionary
-        var newAccounts: [ServiceType: [AuthAccount]] = [:]
-        for type in ServiceType.allCases {
-            newAccounts[type] = []
-        }
-        
+        let files: [URL]
         do {
-            let files = try FileManager.default.contentsOfDirectory(at: authDir, includingPropertiesForKeys: nil)
-            NSLog("[AuthStatus] Scanning %d files in auth directory", files.count)
-            
-            for file in files where file.pathExtension == "json" {
-                NSLog("[AuthStatus] Checking file: %@", file.lastPathComponent)
-                guard let data = try? Data(contentsOf: file),
-                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                      let type = json["type"] as? String,
-                      let serviceType = ServiceType(authFileType: type) else {
-                    continue
-                }
-                
-                NSLog("[AuthStatus] Found type '%@' in %@", type, file.lastPathComponent)
-                
-                let email = json["email"] as? String
-                let login = json["login"] as? String
-                var expiredDate: Date?
-                
-                if let expiredStr = json["expired"] as? String {
-                    for formatter in Self.dateFormatters {
-                        if let date = formatter.date(from: expiredStr) {
-                            expiredDate = date
-                            break
-                        }
-                    }
-                }
-                
-                let isDisabled = json["disabled"] as? Bool ?? false
-                
-                let account = AuthAccount(
-                    id: file.lastPathComponent,
-                    email: email,
-                    login: login,
-                    type: serviceType,
-                    expired: expiredDate,
-                    filePath: file,
-                    isDisabled: isDisabled
-                )
-                
-                newAccounts[serviceType]?.append(account)
-                NSLog("[AuthStatus] Found %@ auth: %@", serviceType.displayName, account.displayName)
-            }
-            
-            // Update on main thread
-            DispatchQueue.main.async {
-                for type in ServiceType.allCases {
-                    self.serviceAccounts[type] = ServiceAccounts(
-                        type: type,
-                        accounts: newAccounts[type] ?? []
-                    )
-                }
-            }
+            files = try FileManager.default.contentsOfDirectory(at: authDir, includingPropertiesForKeys: nil)
         } catch {
             NSLog("[AuthStatus] Error checking auth status: %@", error.localizedDescription)
-            DispatchQueue.main.async {
-                for type in ServiceType.allCases {
-                    self.serviceAccounts[type] = ServiceAccounts(type: type)
-                }
-            }
+            let empty = Self.emptyAccounts()
+            DispatchQueue.main.async { self.serviceAccounts = empty }
+            return
+        }
+
+        NSLog("[AuthStatus] Scanning %d files in auth directory", files.count)
+        var newAccounts = Self.emptyAccounts()
+        for file in files where file.pathExtension == "json" {
+            NSLog("[AuthStatus] Checking file: %@", file.lastPathComponent)
+            guard let account = parseAccount(from: file) else { continue }
+            newAccounts[account.type]?.accounts.append(account)
+            NSLog("[AuthStatus] Found %@ auth: %@", account.type.displayName, account.displayName)
+        }
+
+        DispatchQueue.main.async {
+            self.serviceAccounts = newAccounts
         }
     }
-    
+
     /// Toggle the disabled state of a specific account's auth file
     func toggleAccountDisabled(_ account: AuthAccount) -> Bool {
         do {
@@ -198,18 +141,50 @@ class AuthManager: ObservableObject {
             return false
         }
     }
-    
+
     /// Delete a specific account's auth file
     func deleteAccount(_ account: AuthAccount) -> Bool {
         do {
             try FileManager.default.removeItem(at: account.filePath)
             NSLog("[AuthStatus] Deleted auth file: %@", account.filePath.path)
-            // Refresh status
             checkAuthStatus()
             return true
         } catch {
             NSLog("[AuthStatus] Failed to delete auth file: %@", error.localizedDescription)
             return false
         }
+    }
+
+    private static func emptyAccounts() -> [ServiceType: ServiceAccounts] {
+        Dictionary(uniqueKeysWithValues: ServiceType.allCases.map { ($0, ServiceAccounts(type: $0)) })
+    }
+
+    private func parseAccount(from file: URL) -> AuthAccount? {
+        guard let data = try? Data(contentsOf: file),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let typeString = json["type"] as? String,
+              let serviceType = ServiceType(authFileType: typeString) else {
+            return nil
+        }
+
+        NSLog("[AuthStatus] Found type '%@' in %@", typeString, file.lastPathComponent)
+
+        return AuthAccount(
+            id: file.lastPathComponent,
+            email: json["email"] as? String,
+            login: json["login"] as? String,
+            type: serviceType,
+            expired: parseExpiry(json["expired"] as? String),
+            filePath: file,
+            isDisabled: json["disabled"] as? Bool ?? false
+        )
+    }
+
+    private func parseExpiry(_ value: String?) -> Date? {
+        guard let value else { return nil }
+        for formatter in Self.dateFormatters {
+            if let date = formatter.date(from: value) { return date }
+        }
+        return nil
     }
 }

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -56,14 +56,12 @@ struct DroidProxyModelDefinition: Equatable {
         ]
         guard !levels.isEmpty else { return entry }
         entry["enableThinking"] = true
-        let defLevel = levels.count == 1 ? levels[0].value : defaultLevelValue
-        entry["reasoningEffort"] = defLevel
+        entry["reasoningEffort"] = levels.count == 1 ? levels[0].value : defaultLevelValue
         return entry
     }
 }
 
 enum DroidProxyModelCatalog {
-    private static let minimal = DroidProxyThinkingLevel(value: "minimal", displayName: "Minimal")
     private static let low = DroidProxyThinkingLevel(value: "low", displayName: "Low")
     private static let medium = DroidProxyThinkingLevel(value: "medium", displayName: "Medium")
     private static let high = DroidProxyThinkingLevel(value: "high", displayName: "High")
@@ -73,21 +71,13 @@ enum DroidProxyModelCatalog {
     private static let claudeAdvancedLevels = [low, medium, high, xhigh, max]
     private static let claudeClassicLevels = [low, medium, high, max]
     private static let codexLevels = [low, medium, high, xhigh]
-    private static let kimiLevels = [high]
-    private static let antigravityLowLevel = [low]
-    private static let antigravityMediumLevel = [medium]
-    private static let antigravityHighLevel = [high]
-    private static let gemini35FlashAntigravityLevels = [medium, high]
-    private static let geminiProLevels = [low, medium, high]
-    private static let geminiFlashLevels = [minimal, low, medium, high]
-    private static let cursorLevels = [high]
 
     private static func antigravityModel(
         baseModel: String,
         idSlug: String,
         displayName: String,
         maxOutputTokens: Int = 65536,
-        levels: [DroidProxyThinkingLevel] = antigravityHighLevel,
+        levels: [DroidProxyThinkingLevel] = [high],
         defaultLevelValue: String = "high"
     ) -> DroidProxyModelDefinition {
         DroidProxyModelDefinition(
@@ -215,7 +205,7 @@ enum DroidProxyModelCatalog {
                 baseModel: "gemini-3.1-pro-low",
                 idSlug: "gemini-3.1-pro-low",
                 displayName: "Gemini 3.1 Pro (Low)",
-                levels: antigravityLowLevel,
+                levels: [low],
                 defaultLevelValue: "low"
             ),
             antigravityModel(
@@ -227,14 +217,14 @@ enum DroidProxyModelCatalog {
                 baseModel: "gemini-3-flash-agent",
                 idSlug: "gemini-3.5-flash",
                 displayName: "Gemini 3.5 Flash",
-                levels: gemini35FlashAntigravityLevels,
+                levels: [medium, high],
                 defaultLevelValue: "high"
             ),
             antigravityModel(
                 baseModel: "gemini-3.5-flash-low",
                 idSlug: "gemini-3.5-flash-low",
                 displayName: "Gemini 3.5 Flash (Low)",
-                levels: antigravityLowLevel,
+                levels: [low],
                 defaultLevelValue: "low"
             ),
             antigravityModel(
@@ -259,7 +249,7 @@ enum DroidProxyModelCatalog {
                 idSlug: "gpt-oss-120b-medium",
                 displayName: "GPT-OSS 120B (Medium)",
                 maxOutputTokens: 32768,
-                levels: antigravityMediumLevel,
+                levels: [medium],
                 defaultLevelValue: "medium"
             ),
             DroidProxyModelDefinition(
@@ -271,7 +261,7 @@ enum DroidProxyModelCatalog {
                 providerKey: "kimi",
                 baseURL: "http://localhost:8317/v1",
                 kind: .kimi,
-                levels: kimiLevels,
+                levels: [high],
                 defaultLevelValue: "high"
             )
         ]
@@ -287,7 +277,7 @@ enum DroidProxyModelCatalog {
                     providerKey: "cursor",
                     baseURL: "http://localhost:8317/v1",
                     kind: .cursor,
-                    levels: cursorLevels,
+                    levels: [high],
                     defaultLevelValue: "high"
                 ),
                 DroidProxyModelDefinition(
@@ -299,7 +289,7 @@ enum DroidProxyModelCatalog {
                     providerKey: "cursor",
                     baseURL: "http://localhost:8317/v1",
                     kind: .cursor,
-                    levels: cursorLevels,
+                    levels: [high],
                     defaultLevelValue: "high"
                 )
             ])
@@ -318,5 +308,4 @@ enum DroidProxyModelCatalog {
     static var allSettingsIDs: Set<String> {
         Set(definitions.map(\.simpleID))
     }
-
 }

--- a/src/Sources/IconCatalog.swift
+++ b/src/Sources/IconCatalog.swift
@@ -11,33 +11,39 @@ final class IconCatalog {
     
     func image(named name: String, resizedTo size: NSSize? = nil, template: Bool = false) -> NSImage? {
         let key = cacheKey(name: name, size: size, template: template)
-        
-        cacheLock.lock()
-        if let cached = cache[key] {
-            cacheLock.unlock()
+
+        if let cached = readCache(key: key) {
             return cached.copy() as? NSImage
         }
-        cacheLock.unlock()
-        
+
         guard let resourcePath = bundle.resourcePath else { return nil }
         let iconPath = (resourcePath as NSString).appendingPathComponent(name)
         guard let baseImage = NSImage(contentsOfFile: iconPath) else { return nil }
-        
+
         let image = baseImage.copy() as? NSImage ?? baseImage
-        if let size = size {
+        if let size {
             image.size = size
         }
         image.isTemplate = template
-        
-        cacheLock.lock()
-        cache[key] = image
-        cacheLock.unlock()
-        
+
+        writeCache(key: key, image: image)
         return image.copy() as? NSImage ?? image
     }
-    
+
+    private func readCache(key: String) -> NSImage? {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        return cache[key]
+    }
+
+    private func writeCache(key: String, image: NSImage) {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        cache[key] = image
+    }
+
     private func cacheKey(name: String, size: NSSize?, template: Bool) -> String {
-        if let size = size {
+        if let size {
             return "\(name)-\(Int(size.width))x\(Int(size.height))-\(template)"
         }
         return "\(name)-original-\(template)"

--- a/src/Sources/OAuthUsageTracker.swift
+++ b/src/Sources/OAuthUsageTracker.swift
@@ -56,27 +56,16 @@ final class OAuthUsageTracker: ObservableObject {
         }
 
         isRefreshing = true
-        
-        var initialAccounts: [OAuthAccountUsage] = []
-        for account in enabledCodex {
-            initialAccounts.append(OAuthAccountUsage(id: account.id, provider: .codex, email: account.displayName, isLoading: true))
-        }
-        for account in enabledClaude {
-            initialAccounts.append(OAuthAccountUsage(id: account.id, provider: .claude, email: account.displayName, isLoading: true))
-        }
-        accounts = initialAccounts
+        accounts = enabledCodex.map { Self.loadingPlaceholder(for: $0, provider: .codex) }
+            + enabledClaude.map { Self.loadingPlaceholder(for: $0, provider: .claude) }
 
         refreshTask = Task { [enabledCodex, enabledClaude] in
             let results = await withTaskGroup(of: OAuthAccountUsage.self) { group in
                 for account in enabledCodex {
-                    group.addTask {
-                        await Self.fetchCodexUsage(for: account)
-                    }
+                    group.addTask { await Self.fetchCodexUsage(for: account) }
                 }
                 for account in enabledClaude {
-                    group.addTask {
-                        await Self.fetchClaudeUsage(for: account)
-                    }
+                    group.addTask { await Self.fetchClaudeUsage(for: account) }
                 }
 
                 var values: [OAuthAccountUsage] = []
@@ -95,6 +84,10 @@ final class OAuthUsageTracker: ObservableObject {
             self.accounts = results
             self.isRefreshing = false
         }
+    }
+
+    nonisolated private static func loadingPlaceholder(for account: AuthAccount, provider: ServiceType) -> OAuthAccountUsage {
+        OAuthAccountUsage(id: account.id, provider: provider, email: account.displayName, isLoading: true)
     }
 
     nonisolated private static func fetchCodexUsage(for account: AuthAccount) async -> OAuthAccountUsage {
@@ -127,46 +120,42 @@ final class OAuthUsageTracker: ObservableObject {
             return failedAccount(account, "Missing access token")
         }
 
-        var currentToken = token
-        
-        // Determine expiration
-        let isExpired: Bool
-        if let expiredStr = auth["expired"],
-           let expiredDate = parseISO8601Date(expiredStr) {
-            isExpired = expiredDate <= Date()
-        } else {
-            isExpired = false
-        }
+        let isExpired = auth["expired"]
+            .flatMap(parseISO8601Date)
+            .map { $0 <= Date() } ?? false
 
+        let usableToken: String
         if isExpired {
             do {
-                currentToken = try await refreshClaudeTokens(fileURL: account.filePath, auth: auth)
+                usableToken = try await refreshClaudeTokens(fileURL: account.filePath, auth: auth)
             } catch {
                 return failedAccount(account, "Token refresh failed: \(error.localizedDescription)")
             }
+        } else {
+            usableToken = token
         }
 
-        return await executeClaudeUsageRequest(account: account, token: currentToken)
+        return await executeClaudeUsageRequest(account: account, token: usableToken)
     }
 
     nonisolated private static func refreshClaudeTokens(fileURL: URL, auth: [String: String]) async throws -> String {
         guard let refreshToken = auth["refresh_token"] else {
             throw NSError(domain: "ClaudeUsage", code: 2, userInfo: [NSLocalizedDescriptionKey: "No refresh token available"])
         }
-        
+
         var request = URLRequest(url: URL(string: "https://platform.claude.com/v1/oauth/token")!)
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-        
+
         let encodedToken = refreshToken.addingPercentEncoding(withAllowedCharacters: OAuthUsageParsing.formURLEncodedAllowedCharacters) ?? ""
         let body = "client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&grant_type=refresh_token&refresh_token=\(encodedToken)"
         request.httpBody = body.data(using: .utf8)
-        
+
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             throw NSError(domain: "ClaudeUsage", code: 3, userInfo: [NSLocalizedDescriptionKey: "Token refresh failed"])
         }
-        
+
         guard let newTokens = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let newAccess = newTokens["access_token"] as? String,
               let newRefresh = newTokens["refresh_token"] as? String else {
@@ -194,70 +183,68 @@ final class OAuthUsageTracker: ObservableObject {
         guard let url = URL(string: "https://api.anthropic.com/api/oauth/usage") else {
             return failedAccount(account, "Invalid usage endpoint")
         }
-        
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: makeClaudeUsageRequest(url: url, token: token))
+            guard let http = response as? HTTPURLResponse else {
+                return failedAccount(account, "No HTTP response")
+            }
+
+            if http.statusCode == 401 || http.statusCode == 403 {
+                return await retryClaudeUsageAfterRefresh(account: account, url: url)
+            }
+
+            guard (200..<300).contains(http.statusCode) else {
+                return failedAccount(account, "Claude usage API returned \(http.statusCode)")
+            }
+
+            let windows = parseClaudeWindows(data)
+            guard !windows.isEmpty else {
+                return failedAccount(account, "Usage response did not include quota windows")
+            }
+
+            return successAccount(account, windows: windows)
+        } catch {
+            return failedAccount(account, error.localizedDescription)
+        }
+    }
+
+    nonisolated private static func retryClaudeUsageAfterRefresh(account: AuthAccount, url: URL) async -> OAuthAccountUsage {
+        do {
+            guard let auth = authValues(from: account.filePath) else {
+                return failedAccount(account, "Failed to read credentials for retry")
+            }
+            let newToken = try await refreshClaudeTokens(fileURL: account.filePath, auth: auth)
+            let (data, response) = try await URLSession.shared.data(for: makeClaudeUsageRequest(url: url, token: newToken))
+            guard let http = response as? HTTPURLResponse else {
+                return failedAccount(account, "No HTTP response on retry")
+            }
+            guard http.statusCode == 200 else {
+                return failedAccount(account, "Claude usage returned \(http.statusCode) after refresh retry")
+            }
+            return successAccount(account, windows: parseClaudeWindows(data))
+        } catch {
+            return failedAccount(account, "Retry token refresh failed: \(error.localizedDescription)")
+        }
+    }
+
+    nonisolated private static func makeClaudeUsageRequest(url: URL, token: String) -> URLRequest {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.timeoutInterval = OAuthUsageParsing.requestTimeout
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        return request
+    }
 
-        do {
-            let (data, response) = try await URLSession.shared.data(for: request)
-            guard let http = response as? HTTPURLResponse else {
-                return failedAccount(account, "No HTTP response")
-            }
-            
-            if http.statusCode == 401 || http.statusCode == 403 {
-                do {
-                    guard let auth = authValues(from: account.filePath) else {
-                        return failedAccount(account, "Failed to read credentials for retry")
-                    }
-                    let newTokens = try await refreshClaudeTokens(fileURL: account.filePath, auth: auth)
-                    var retryRequest = URLRequest(url: url)
-                    retryRequest.httpMethod = "GET"
-                    retryRequest.timeoutInterval = OAuthUsageParsing.requestTimeout
-                    retryRequest.setValue("Bearer \(newTokens)", forHTTPHeaderField: "Authorization")
-                    retryRequest.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
-                    
-                    let (retryData, retryResponse) = try await URLSession.shared.data(for: retryRequest)
-                    guard let retryHttp = retryResponse as? HTTPURLResponse else {
-                        return failedAccount(account, "No HTTP response on retry")
-                    }
-                    guard retryHttp.statusCode == 200 else {
-                        return failedAccount(account, "Claude usage returned \(retryHttp.statusCode) after refresh retry")
-                    }
-                    let windows = parseClaudeWindows(retryData)
-                    return OAuthAccountUsage(
-                        id: account.id,
-                        provider: account.type,
-                        email: account.displayName,
-                        windows: windows,
-                        updatedAt: Date()
-                    )
-                } catch {
-                    return failedAccount(account, "Retry token refresh failed: \(error.localizedDescription)")
-                }
-            }
-            
-            guard (200..<300).contains(http.statusCode) else {
-                return failedAccount(account, "Claude usage API returned \(http.statusCode)")
-            }
-            
-            let windows = parseClaudeWindows(data)
-            guard !windows.isEmpty else {
-                return failedAccount(account, "Usage response did not include quota windows")
-            }
-            
-            return OAuthAccountUsage(
-                id: account.id,
-                provider: account.type,
-                email: account.displayName,
-                windows: windows,
-                updatedAt: Date()
-            )
-        } catch {
-            return failedAccount(account, error.localizedDescription)
-        }
+    nonisolated private static func successAccount(_ account: AuthAccount, windows: [OAuthUsageWindow]) -> OAuthAccountUsage {
+        OAuthAccountUsage(
+            id: account.id,
+            provider: account.type,
+            email: account.displayName,
+            windows: windows,
+            updatedAt: Date()
+        )
     }
 
     nonisolated private static func parseClaudeWindows(_ data: Data) -> [OAuthUsageWindow] {
@@ -285,7 +272,7 @@ final class OAuthUsageTracker: ObservableObject {
             let resetsAtStr = dict["resets_at"] as? String
             let resetDate = resetsAtStr.flatMap(parseISO8601Date)
             let resetText = resetDate.map(resetText(for:)) ?? resetsAtStr
-            
+
             windows.append(OAuthUsageWindow(
                 title: title,
                 usedPercent: usedPercent,
@@ -315,13 +302,7 @@ final class OAuthUsageTracker: ObservableObject {
             guard !windows.isEmpty else {
                 return failedAccount(account, "Usage response did not include quota windows")
             }
-            return OAuthAccountUsage(
-                id: account.id,
-                provider: account.type,
-                email: account.displayName,
-                windows: windows,
-                updatedAt: Date()
-            )
+            return successAccount(account, windows: windows)
         } catch {
             return failedAccount(account, error.localizedDescription)
         }

--- a/src/Sources/ServerManager.swift
+++ b/src/Sources/ServerManager.swift
@@ -56,10 +56,6 @@ class ServerManager: ObservableObject {
         }
     }
 
-    /// Helper class to capture output text across closures
-    private class OutputCapture {
-        var text = ""
-    }
     private var logBuffer: RingBuffer<String>
     private let maxLogLines = 1000
     private let processQueue = DispatchQueue(label: "io.automaze.droidproxy.server-process", qos: .userInitiated)
@@ -118,77 +114,62 @@ class ServerManager: ObservableObject {
         // Clean up any orphaned processes from previous crashes
         killOrphanedProcesses()
 
-        // Use bundled binary from app bundle
-        guard let resourcePath = Bundle.main.resourcePath else {
-            addLog("❌ Error: Could not find resource path")
+        guard let bundledPath = bundledBinaryPath() else {
+            addLog("❌ Error: cli-proxy-api-plus binary not found in app bundle")
             completion(false)
             return
         }
-        
-        let bundledPath = (resourcePath as NSString).appendingPathComponent("cli-proxy-api-plus")
-        guard FileManager.default.fileExists(atPath: bundledPath) else {
-            addLog("❌ Error: cli-proxy-api-plus binary not found at \(bundledPath)")
-            completion(false)
-            return
-        }
-        
-        // Use config path (merged with Z.AI if keys exist)
+
+        // Use config path (merged with user settings and provider exclusions)
         let configPath = getConfigPath()
-        guard !configPath.isEmpty && FileManager.default.fileExists(atPath: configPath) else {
+        guard !configPath.isEmpty, FileManager.default.fileExists(atPath: configPath) else {
             addLog("❌ Error: config.yaml not found")
             completion(false)
             return
         }
         
-        process = Process()
-        process?.executableURL = URL(fileURLWithPath: bundledPath)
-        process?.arguments = ["-config", configPath]
-        
-        // Setup pipes for output
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: bundledPath)
+        proc.arguments = ["-config", configPath]
+
         let outputPipe = Pipe()
         let errorPipe = Pipe()
-        process?.standardOutput = outputPipe
-        process?.standardError = errorPipe
-        
-        // Handle output
+        proc.standardOutput = outputPipe
+        proc.standardError = errorPipe
+
         outputPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
-            let data = handle.availableData
-            if let output = String(data: data, encoding: .utf8), !output.isEmpty {
-                self?.addLog(output)
-            }
+            guard let output = String(data: handle.availableData, encoding: .utf8), !output.isEmpty else { return }
+            self?.addLog(output)
         }
-        
+
         errorPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
-            let data = handle.availableData
-            if let output = String(data: data, encoding: .utf8), !output.isEmpty {
-                self?.addLog("⚠️ \(output)")
-            }
+            guard let output = String(data: handle.availableData, encoding: .utf8), !output.isEmpty else { return }
+            self?.addLog("⚠️ \(output)")
         }
-        
-        // Handle termination
-        process?.terminationHandler = { [weak self] process in
-            // Clear pipe handlers to prevent memory leaks
+
+        proc.terminationHandler = { [weak self] process in
+            // Clear pipe handlers to prevent retain cycles on the file handles.
             outputPipe.fileHandleForReading.readabilityHandler = nil
             errorPipe.fileHandleForReading.readabilityHandler = nil
-            
+
             DispatchQueue.main.async {
                 self?.isRunning = false
                 self?.addLog("Server stopped with code: \(process.terminationStatus)")
                 NotificationCenter.default.post(name: .serverStatusChanged, object: nil)
             }
         }
-        
+
+        process = proc
+
         do {
-            try process?.run()
-            DispatchQueue.main.async {
-                self.isRunning = true
-            }
+            try proc.run()
+            DispatchQueue.main.async { self.isRunning = true }
             addLog("✓ Server started on port \(port)")
-            
-            // Wait a bit to ensure it started successfully
+
+            // Give the backend a moment to actually bind before reporting success.
             DispatchQueue.main.asyncAfter(deadline: .now() + Timing.readinessCheckDelay) { [weak self] in
                 guard let self = self else { return }
-                if let process = self.process, process.isRunning {
+                if let running = self.process, running.isRunning {
                     NotificationCenter.default.post(name: .serverStatusChanged, object: nil)
                     completion(true)
                 } else {
@@ -245,112 +226,98 @@ class ServerManager: ObservableObject {
     }
     
     func runAuthCommand(_ command: AuthCommand, completion: @escaping (Bool, String) -> Void) {
-        // Use bundled binary from app bundle
-        guard let resourcePath = Bundle.main.resourcePath else {
-            completion(false, "Could not find resource path")
+        guard let bundledPath = bundledBinaryPath(),
+              let resourcePath = Bundle.main.resourcePath else {
+            completion(false, "cli-proxy-api-plus binary not found in app bundle")
             return
         }
-        
-        let bundledPath = (resourcePath as NSString).appendingPathComponent("cli-proxy-api-plus")
-        guard FileManager.default.fileExists(atPath: bundledPath) else {
-            completion(false, "Binary not found at \(bundledPath)")
-            return
-        }
-        
-        let authProcess = Process()
-        authProcess.executableURL = URL(fileURLWithPath: bundledPath)
 
-        // Get the config path
+        // Auth flow uses the bundled (unmerged) config; user-specific overrides
+        // aren't needed for OAuth login itself.
         let configPath = (resourcePath as NSString).appendingPathComponent("config.yaml")
 
-        switch command {
-        case .claudeLogin:
-            authProcess.arguments = ["--config", configPath, "-claude-login"]
-        case .codexLogin:
-            authProcess.arguments = ["--config", configPath, "-codex-login"]
-        case .antigravityLogin:
-            authProcess.arguments = ["--config", configPath, "-antigravity-login"]
-        case .kimiLogin:
-            authProcess.arguments = ["--config", configPath, "-kimi-login"]
-        }
+        let authProcess = Process()
+        authProcess.executableURL = URL(fileURLWithPath: bundledPath)
+        authProcess.arguments = ["--config", configPath, command.loginFlag]
+        authProcess.environment = ProcessInfo.processInfo.environment
 
-        // Create pipes for output
         let outputPipe = Pipe()
         let errorPipe = Pipe()
         let inputPipe = Pipe()
         authProcess.standardOutput = outputPipe
         authProcess.standardError = errorPipe
         authProcess.standardInput = inputPipe
-        
-        let capture = OutputCapture()
-        
+
         // For Codex login, avoid blocking on the manual callback prompt after ~15s.
         if case .codexLogin = command {
             DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 12.0) {
-                if authProcess.isRunning {
-                    if let data = "\n".data(using: .utf8) {
-                        try? inputPipe.fileHandleForWriting.write(contentsOf: data)
-                        NSLog("[Auth] Sent newline to keep Codex login waiting for callback")
-                    }
-                }
+                guard authProcess.isRunning, let data = "\n".data(using: .utf8) else { return }
+                try? inputPipe.fileHandleForWriting.write(contentsOf: data)
+                NSLog("[Auth] Sent newline to keep Codex login waiting for callback")
             }
         }
 
-        // Set environment to inherit from parent
-        authProcess.environment = ProcessInfo.processInfo.environment
-        
+        let browserOpenedMessage = "🌐 Browser opened for authentication.\n\nPlease complete the login in your browser.\n\nThe app will automatically detect when you're authenticated."
+
         do {
             NSLog("[Auth] Starting process: %@ with args: %@", bundledPath, authProcess.arguments?.joined(separator: " ") ?? "none")
             try authProcess.run()
             addLog("✓ Authentication process started (PID: \(authProcess.processIdentifier)) - browser should open shortly")
             NSLog("[Auth] Process started with PID: %d", authProcess.processIdentifier)
-            
-            // Set up termination handler to detect when auth completes
+
+            // Notify watchers when auth completes successfully so the UI can pick
+            // up the freshly written credential file.
             authProcess.terminationHandler = { process in
-                let exitCode = process.terminationStatus
-                NSLog("[Auth] Process terminated with exit code: %d", exitCode)
-                
-                if exitCode == 0 {
-                    // Authentication completed successfully
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        // Give file system a moment to write the credential file
-                        NotificationCenter.default.post(name: .authDirectoryChanged, object: nil)
-                    }
+                NSLog("[Auth] Process terminated with exit code: %d", process.terminationStatus)
+                guard process.terminationStatus == 0 else { return }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    NotificationCenter.default.post(name: .authDirectoryChanged, object: nil)
                 }
             }
-            
+
             // Wait briefly to check if process crashes immediately
             DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1.0) {
                 if authProcess.isRunning {
                     NSLog("[Auth] Process running after wait, returning success")
-                    completion(true, "🌐 Browser opened for authentication.\n\nPlease complete the login in your browser.\n\nThe app will automatically detect when you're authenticated.")
+                    completion(true, browserOpenedMessage)
+                    return
+                }
+
+                // Process died quickly - check stdout/stderr for clues.
+                let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                let error = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+                NSLog("[Auth] Process died quickly - output: %@", output.isEmpty ? "(empty)" : String(output.prefix(200)))
+
+                if output.contains("Opening browser") || output.contains("Attempting to open URL") {
+                    // Browser opened but process finished — treat as success.
+                    NSLog("[Auth] Browser opened, process completed")
+                    completion(true, browserOpenedMessage)
                 } else {
-                    // Process died quickly - check for error
-                    let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-                    let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-                    
-                    var output = String(data: outputData, encoding: .utf8) ?? ""
-                    if output.isEmpty { output = capture.text }
-                    let error = String(data: errorData, encoding: .utf8) ?? ""
-                    
-                    NSLog("[Auth] Process died quickly - output: %@", output.isEmpty ? "(empty)" : String(output.prefix(200)))
-                    
-                    if output.contains("Opening browser") || output.contains("Attempting to open URL") {
-                        // Browser opened but process finished (probably success)
-                        NSLog("[Auth] Browser opened, process completed")
-                        completion(true, "🌐 Browser opened for authentication.\n\nPlease complete the login in your browser.\n\nThe app will automatically detect when you're authenticated.")
+                    NSLog("[Auth] Process failed")
+                    let message: String
+                    if !error.isEmpty {
+                        message = error
+                    } else if !output.isEmpty {
+                        message = output
                     } else {
-                        // Real error
-                        NSLog("[Auth] Process failed")
-                        let message = error.isEmpty ? (output.isEmpty ? "Authentication process failed unexpectedly" : output) : error
-                        completion(false, message)
+                        message = "Authentication process failed unexpectedly"
                     }
+                    completion(false, message)
                 }
             }
         } catch {
             NSLog("[Auth] Failed to start: %@", error.localizedDescription)
             completion(false, "Failed to start auth process: \(error.localizedDescription)")
         }
+    }
+
+    /// Resolves the path to the bundled `cli-proxy-api-plus` binary, returning
+    /// `nil` if the resource directory or binary is missing.
+    private func bundledBinaryPath() -> String? {
+        guard let resourcePath = Bundle.main.resourcePath else { return nil }
+        let path = (resourcePath as NSString).appendingPathComponent("cli-proxy-api-plus")
+        return FileManager.default.fileExists(atPath: path) ? path : nil
     }
     
     private func addLog(_ message: String) {
@@ -402,24 +369,16 @@ class ServerManager: ObservableObject {
             with: "logging-to-file: \(verboseLogging)"
         )
 
-        // Build list of disabled providers
-        var disabledProviders: [String] = []
-        for (serviceType, oauthKey) in Self.oauthProviderKeys {
-            if !isProviderEnabled(serviceType) {
-                disabledProviders.append(oauthKey)
-            }
-        }
+        // Append provider exclusions for any provider toggled off in the UI.
+        let disabledProviders = Self.oauthProviderKeys
+            .filter { !isProviderEnabled($0.key) }
+            .map { $0.value }
+            .sorted()
 
         if !disabledProviders.isEmpty {
-            configContent += """
-
-# Provider exclusions (auto-added by DroidProxy)
-oauth-excluded-models:
-
-"""
-            for provider in disabledProviders.sorted() {
-                configContent += "  \(provider):\n"
-                configContent += "    - \"*\"\n"
+            configContent += "\n# Provider exclusions (auto-added by DroidProxy)\noauth-excluded-models:\n"
+            for provider in disabledProviders {
+                configContent += "  \(provider):\n    - \"*\"\n"
             }
         }
 
@@ -489,4 +448,14 @@ enum AuthCommand: Equatable {
     case codexLogin
     case antigravityLogin
     case kimiLogin
+
+    /// CLI flag passed to `cli-proxy-api-plus` for this login flow.
+    var loginFlag: String {
+        switch self {
+        case .claudeLogin: return "-claude-login"
+        case .codexLogin: return "-codex-login"
+        case .antigravityLogin: return "-antigravity-login"
+        case .kimiLogin: return "-kimi-login"
+        }
+    }
 }

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -78,27 +78,58 @@ extension View {
             self.buttonStyle(.bordered)
         }
     }
+
+    /// Pushes the pointing-hand cursor while hovered. The `enabled` flag lets
+    /// callers gate the cursor change on a runtime condition (e.g. disabled
+    /// buttons should keep the default cursor).
+    func pointingHandCursor(enabled: Bool = true) -> some View {
+        onHover { inside in
+            guard enabled else { return }
+            if inside {
+                NSCursor.pointingHand.push()
+            } else {
+                NSCursor.pop()
+            }
+        }
+    }
 }
 
 /// A single account row with disable toggle and remove button
 struct AccountRowView: View {
     static let accent = Color(red: 0xF2/255, green: 0x7B/255, blue: 0x2F/255)
-    
+
     let account: AuthAccount
     let removeColor: Color
     let showDisableToggle: Bool
     let isLastEnabled: Bool
     let onToggleDisabled: () -> Void
     let onRemove: () -> Void
-    
+
+    private var statusColor: Color {
+        if account.isDisabled { return .gray }
+        if account.isExpired { return Self.accent.opacity(0.6) }
+        return Self.accent
+    }
+
+    private var nameColor: Color {
+        if account.isDisabled { return .secondary.opacity(0.5) }
+        if account.isExpired { return Self.accent.opacity(0.6) }
+        return .secondary
+    }
+
+    private func disableButtonColor(canDisable: Bool) -> Color {
+        if account.isDisabled { return Self.accent }
+        return canDisable ? Self.accent.opacity(0.6) : .secondary.opacity(0.4)
+    }
+
     var body: some View {
         HStack(spacing: 8) {
             Circle()
-                .fill(account.isDisabled ? Color.gray : (account.isExpired ? Self.accent.opacity(0.6) : Self.accent))
+                .fill(statusColor)
                 .frame(width: 6, height: 6)
             Text(account.displayName)
                 .font(.caption)
-                .foregroundColor(account.isDisabled ? .secondary.opacity(0.5) : (account.isExpired ? Self.accent.opacity(0.6) : .secondary))
+                .foregroundColor(nameColor)
                 .strikethrough(account.isDisabled)
             if account.isExpired && !account.isDisabled {
                 Text("(expired)")
@@ -115,16 +146,12 @@ struct AccountRowView: View {
                 Button(action: onToggleDisabled) {
                     Text(account.isDisabled ? "Enable" : "Disable")
                         .font(.caption)
-                        .foregroundColor(account.isDisabled ? Self.accent : (canDisable ? Self.accent.opacity(0.6) : .secondary.opacity(0.4)))
+                        .foregroundColor(disableButtonColor(canDisable: canDisable))
                 }
                 .buttonStyle(.plain)
                 .disabled(!canDisable)
                 .help(!canDisable ? "At least one account must remain enabled" : "")
-                .onHover { inside in
-                    if canDisable {
-                        if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
-                }
+                .pointingHandCursor(enabled: canDisable)
             }
             Button(action: onRemove) {
                 HStack(spacing: 2) {
@@ -136,9 +163,7 @@ struct AccountRowView: View {
                 .foregroundColor(removeColor)
             }
             .buttonStyle(.plain)
-            .onHover { inside in
-                if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-            }
+            .pointingHandCursor()
         }
         .padding(.leading, 28)
     }
@@ -317,7 +342,6 @@ struct SettingsView: View {
     @State private var authenticatingService: ServiceType? = nil
     @State private var showingAuthResult = false
     @State private var authResultMessage = ""
-    @State private var authResultSuccess = false
     @State private var showingCursorApiKeyAlert = false
     @State private var cursorApiKey = ""
     @State private var authDirectoryMonitor: AuthDirectoryMonitor?
@@ -469,9 +493,7 @@ struct SettingsView: View {
                         .font(.caption)
                         .foregroundColor(Color.white.opacity(0.75))
                         .help("Enable beta-gated features")
-                        .onHover { inside in
-                            if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                        }
+                        .pointingHandCursor()
                     Spacer()
                     HStack(spacing: 8) {
                         HStack(spacing: 4) {
@@ -503,9 +525,7 @@ struct SettingsView: View {
                         }
                         .buttonStyle(.plain)
                         .help(oledTheme ? "Switch to Liquid Glass theme" : "Switch to OLED black theme")
-                        .onHover { inside in
-                            if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                        }
+                        .pointingHandCursor()
                     }
                 }
                 .padding(.top, 12)
@@ -692,37 +712,17 @@ struct SettingsView: View {
                 .listRowBackground(glassRowBackground)
 
                 Section("Services") {
-                    ServiceRow(
-                        serviceType: .claude,
+                    providerServiceRow(
+                        .claude,
                         iconName: "icon-claude.png",
-                        accounts: authManager.accounts(for: .claude),
-                        isAuthenticating: authenticatingService == .claude,
-                        helpText: nil,
-                        isEnabled: serverManager.isProviderEnabled(.claude),
-                        customTitle: nil,
-                        onConnect: { connectService(.claude) },
-                        onDisconnect: { account in disconnectAccount(account) },
-                        onToggleDisabled: { account in toggleAccountDisabled(account) },
-                        onToggleEnabled: { enabled in serverManager.setProviderEnabled(.claude, enabled: enabled) },
-                        toggleTint: claudeEffortSelectionColor,
-                        onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
-                    ) { EmptyView() }
+                        toggleTint: claudeEffortSelectionColor
+                    )
 
-                    ServiceRow(
-                        serviceType: .codex,
+                    providerServiceRow(
+                        .codex,
                         iconName: "icon-codex.png",
-                        accounts: authManager.accounts(for: .codex),
-                        isAuthenticating: authenticatingService == .codex,
-                        helpText: nil,
-                        isEnabled: serverManager.isProviderEnabled(.codex),
-                        customTitle: nil,
-                        onConnect: { connectService(.codex) },
-                        onDisconnect: { account in disconnectAccount(account) },
-                        onToggleDisabled: { account in toggleAccountDisabled(account) },
-                        onToggleEnabled: { enabled in serverManager.setProviderEnabled(.codex, enabled: enabled) },
-                        toggleTint: codexEffortSelectionColor,
-                        onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
-                    ) { EmptyView() }
+                        toggleTint: codexEffortSelectionColor
+                    )
 
                     if serverManager.isProviderEnabled(.codex) {
                         VStack(alignment: .leading, spacing: 6) {
@@ -762,56 +762,27 @@ struct SettingsView: View {
                         .padding(.leading, 28)
                     }
 
-                    ServiceRow(
-                        serviceType: .antigravity,
+                    providerServiceRow(
+                        .antigravity,
                         iconName: "icon-gemini.png",
-                        accounts: authManager.accounts(for: .antigravity),
-                        isAuthenticating: authenticatingService == .antigravity,
-                        helpText: "Uses your Antigravity subscription for the Antigravity-backed Gemini, Claude, and GPT-OSS models.",
-                        isEnabled: serverManager.isProviderEnabled(.antigravity),
-                        customTitle: nil,
-                        onConnect: { connectService(.antigravity) },
-                        onDisconnect: { account in disconnectAccount(account) },
-                        onToggleDisabled: { account in toggleAccountDisabled(account) },
-                        onToggleEnabled: { enabled in serverManager.setProviderEnabled(.antigravity, enabled: enabled) },
                         toggleTint: antigravityEffortSelectionColor,
-                        onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
-                    ) { EmptyView() }
+                        helpText: "Uses your Antigravity subscription for the Antigravity-backed Gemini, Claude, and GPT-OSS models."
+                    )
 
-                    ServiceRow(
-                        serviceType: .kimi,
+                    providerServiceRow(
+                        .kimi,
                         iconName: "icon-kimi.svg",
-                        accounts: authManager.accounts(for: .kimi),
-                        isAuthenticating: authenticatingService == .kimi,
-                        helpText: nil,
-                        isEnabled: serverManager.isProviderEnabled(.kimi),
-                        customTitle: nil,
-                        onConnect: { connectService(.kimi) },
-                        onDisconnect: { account in disconnectAccount(account) },
-                        onToggleDisabled: { account in toggleAccountDisabled(account) },
-                        onToggleEnabled: { enabled in serverManager.setProviderEnabled(.kimi, enabled: enabled) },
-                        toggleTint: kimiEffortSelectionColor,
-                        onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
-                    ) { EmptyView() }
+                        toggleTint: kimiEffortSelectionColor
+                    )
 
                     if betaFlag {
-                        ServiceRow(
-                            serviceType: .cursor,
+                        providerServiceRow(
+                            .cursor,
                             iconName: "icon-cursor.png",
-                            accounts: authManager.accounts(for: .cursor),
-                            isAuthenticating: authenticatingService == .cursor,
-                            helpText: "Enter your Cursor API Key (from https://cursor-api.standardagents.ai/) to proxy requests directly to Cursor.",
-                            isEnabled: serverManager.isProviderEnabled(.cursor),
-                            customTitle: nil,
-                            onConnect: { connectService(.cursor) },
-                            onDisconnect: { account in disconnectAccount(account) },
-                            onToggleDisabled: { account in toggleAccountDisabled(account) },
-                            onToggleEnabled: { enabled in serverManager.setProviderEnabled(.cursor, enabled: enabled) },
                             toggleTint: cursorEffortSelectionColor,
-                            onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
-                        ) { EmptyView() }
+                            helpText: "Enter your Cursor API Key (from https://cursor-api.standardagents.ai/) to proxy requests directly to Cursor."
+                        )
                     }
-
                 }
                 .listRowBackground(glassRowBackground)
             }
@@ -832,9 +803,7 @@ struct SettingsView: View {
                         .font(.caption)
                         .underline()
                         .foregroundColor(oledFooterText)
-                        .onHover { inside in
-                            if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                        }
+                        .pointingHandCursor()
                     Text("|")
                         .font(.caption)
                         .foregroundColor(oledFooterText)
@@ -859,9 +828,7 @@ struct SettingsView: View {
                     .padding(.vertical, 4)
                     .droidGlassCapsule(tint: Color.white.opacity(0.08), interactive: true)
                     .padding(.top, 6)
-                    .onHover { inside in
-                        if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
+                    .pointingHandCursor()
             }
             .padding(.bottom, 12)
         }
@@ -929,6 +896,33 @@ struct SettingsView: View {
 
     // MARK: - Actions
 
+    /// Constructs a `ServiceRow` wired up to the standard auth/server callbacks.
+    /// Keeps the body's `Section("Services")` declaration compact and free of
+    /// repeated boilerplate per provider.
+    @ViewBuilder
+    private func providerServiceRow(
+        _ serviceType: ServiceType,
+        iconName: String,
+        toggleTint: Color,
+        helpText: String? = nil
+    ) -> some View {
+        ServiceRow(
+            serviceType: serviceType,
+            iconName: iconName,
+            accounts: authManager.accounts(for: serviceType),
+            isAuthenticating: authenticatingService == serviceType,
+            helpText: helpText,
+            isEnabled: serverManager.isProviderEnabled(serviceType),
+            customTitle: nil,
+            onConnect: { connectService(serviceType) },
+            onDisconnect: { account in disconnectAccount(account) },
+            onToggleDisabled: { account in toggleAccountDisabled(account) },
+            onToggleEnabled: { enabled in serverManager.setProviderEnabled(serviceType, enabled: enabled) },
+            toggleTint: toggleTint,
+            onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
+        ) { EmptyView() }
+    }
+
     @ViewBuilder
     private func codexFastModeToggleRow(_ title: String, isOn: Binding<Bool>, helpText: String) -> some View {
         HStack {
@@ -947,16 +941,13 @@ struct SettingsView: View {
     
     private func toggleAccountDisabled(_ account: AuthAccount) {
         if authManager.toggleAccountDisabled(account) {
-            authResultSuccess = true
             authResultMessage = account.isDisabled
                 ? "✓ Enabled \(account.displayName)"
                 : "✓ Disabled \(account.displayName)"
-            showingAuthResult = true
         } else {
-            authResultSuccess = false
             authResultMessage = "Failed to update \(account.displayName). Please try again."
-            showingAuthResult = true
         }
+        showingAuthResult = true
     }
 
     private func refreshOAuthUsage() {
@@ -1027,23 +1018,20 @@ struct SettingsView: View {
         case .codex: command = .codexLogin
         case .antigravity: command = .antigravityLogin
         case .kimi: command = .kimiLogin
-        case .cursor: command = .kimiLogin // Unreachable but required for exhaustiveness
+        case .cursor: return // handled by the early-return above; defensive
         }
         
         serverManager.runAuthCommand(command) { success, output in
             NSLog("[SettingsView] Auth completed - success: %d, output: %@", success, output)
             DispatchQueue.main.async {
                 self.authenticatingService = nil
-                
                 if success {
-                    self.authResultSuccess = true
                     self.authResultMessage = self.successMessage(for: serviceType)
-                    self.showingAuthResult = true
                 } else {
-                    self.authResultSuccess = false
-                    self.authResultMessage = "Authentication failed. Please check if the browser opened and try again.\n\nDetails: \(output.isEmpty ? "No output from authentication process" : output)"
-                    self.showingAuthResult = true
+                    let details = output.isEmpty ? "No output from authentication process" : output
+                    self.authResultMessage = "Authentication failed. Please check if the browser opened and try again.\n\nDetails: \(details)"
                 }
+                self.showingAuthResult = true
             }
         }
     }
@@ -1082,13 +1070,11 @@ struct SettingsView: View {
             NSLog("[SettingsView] Saved Cursor API Key with secure permissions to \(fileURL.path)")
             
             authManager.checkAuthStatus()
-            
-            self.authResultSuccess = true
+
             self.authResultMessage = "✓ Successfully added Cursor API Key."
             self.showingAuthResult = true
         } catch {
             NSLog("[SettingsView] Failed to save Cursor API Key: \(error.localizedDescription)")
-            self.authResultSuccess = false
             self.authResultMessage = "Failed to save Cursor API Key: \(error.localizedDescription)"
             self.showingAuthResult = true
         }
@@ -1100,10 +1086,8 @@ struct SettingsView: View {
         // Stop server, delete file, restart
         let cleanup = {
             if self.authManager.deleteAccount(account) {
-                self.authResultSuccess = true
                 self.authResultMessage = "✓ Removed \(account.displayName) from \(account.type.displayName)"
             } else {
-                self.authResultSuccess = false
                 self.authResultMessage = "Failed to remove account"
             }
             self.showingAuthResult = true
@@ -1195,12 +1179,10 @@ struct SettingsView: View {
             }
             try data.write(to: url, options: .atomic)
             factoryModelsInstalled = true
-            authResultSuccess = true
             authResultMessage = "DroidProxy models added to Factory settings.\n\nA timestamped backup was saved next to settings.json before writing. Reasoning effort is controlled from Droid CLI per session when the selected model exposes multiple levels. Restart Factory or open a new session to see them in the model picker."
             showingAuthResult = true
             NSLog("[SettingsView] Factory custom models applied to %@", url.path)
         } catch {
-            authResultSuccess = false
             authResultMessage = "Failed to update Factory settings: \(error.localizedDescription)"
             showingAuthResult = true
             NSLog("[SettingsView] Failed to apply Factory custom models: %@", error.localizedDescription)

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -154,65 +154,64 @@ class ThinkingProxy {
     private func receiveNextChunk(from connection: NWConnection, accumulatedData: Data) {
         connection.receive(minimumIncompleteLength: 1, maximumLength: 1048576) { [weak self] data, _, isComplete, error in
             guard let self = self else { return }
-            
+
             if let error = error {
                 NSLog("[ThinkingProxy] Receive error: \(error)")
                 connection.cancel()
                 return
             }
-            
+
             guard let data = data, !data.isEmpty else {
                 if isComplete {
                     connection.cancel()
                 }
                 return
             }
-            
+
             var newAccumulatedData = accumulatedData
             newAccumulatedData.append(data)
-            
+
             // Find the end of headers (\r\n\r\n) using quick binary match to avoid O(N^2) UTF-8 string decodes on every chunk
             let headerEndPattern = Data([13, 10, 13, 10]) // "\r\n\r\n"
-            if let headerEndRange = newAccumulatedData.range(of: headerEndPattern) {
-                // Parse headers only, keeping the massive body as raw binary data
-                let headerData = Data(newAccumulatedData[..<headerEndRange.upperBound])
-                if let headerString = String(data: headerData, encoding: .utf8) {
-                    
-                    // Look for Content-Length
-                    let lines = headerString.components(separatedBy: "\r\n")
-                    if let contentLengthLine = lines.first(where: { $0.lowercased().starts(with: "content-length:") }) {
-                        let parts = contentLengthLine.components(separatedBy: ":")
-                        if parts.count >= 2 {
-                            let contentLengthStr = parts[1].trimmingCharacters(in: .whitespaces)
-                            if let contentLength = Int(contentLengthStr) {
-                                let bodyStartIndex = headerEndRange.upperBound
-                                let currentBodyLength = newAccumulatedData.count - bodyStartIndex
-                                
-                                // If we haven't received the full body yet, schedule next iteration
-                                if currentBodyLength < contentLength {
-                                    if isComplete {
-                                        // End of stream but content length was not met; process the partial bytes we have
-                                        self.processRequest(data: newAccumulatedData, connection: connection)
-                                    } else {
-                                        self.receiveNextChunk(from: connection, accumulatedData: newAccumulatedData)
-                                    }
-                                    return
-                                }
-                            }
-                        }
-                    }
+            guard let headerEndRange = newAccumulatedData.range(of: headerEndPattern) else {
+                if isComplete {
+                    // Complete but malformed (no headers end found); process what we have.
+                    self.processRequest(data: newAccumulatedData, connection: connection)
+                } else {
+                    // Haven't found header end yet; schedule next iteration.
+                    self.receiveNextChunk(from: connection, accumulatedData: newAccumulatedData)
                 }
-                
-                // We have a complete request, process it
-                self.processRequest(data: newAccumulatedData, connection: connection)
-            } else if !isComplete {
-                // Haven't found header end yet, schedule next iteration
-                self.receiveNextChunk(from: connection, accumulatedData: newAccumulatedData)
-            } else {
-                // Complete but malformed (no headers end found), process what we have
-                self.processRequest(data: newAccumulatedData, connection: connection)
+                return
             }
+
+            // If Content-Length advertises more bytes than we've received and the
+            // stream is still open, keep reading. Otherwise (full body, missing
+            // header, or truncated stream) hand off to processRequest.
+            let bodyReceived = newAccumulatedData.count - headerEndRange.upperBound
+            if !isComplete,
+               let contentLength = self.parseContentLength(in: newAccumulatedData[..<headerEndRange.upperBound]),
+               bodyReceived < contentLength {
+                self.receiveNextChunk(from: connection, accumulatedData: newAccumulatedData)
+                return
+            }
+
+            self.processRequest(data: newAccumulatedData, connection: connection)
         }
+    }
+
+    /// Parses the `Content-Length` value from the raw header bytes of an HTTP
+    /// request. Returns nil if the header is missing or unparseable.
+    private func parseContentLength(in headerData: Data) -> Int? {
+        guard let headerString = String(data: headerData, encoding: .utf8) else {
+            return nil
+        }
+        for line in headerString.components(separatedBy: "\r\n")
+            where line.lowercased().hasPrefix("content-length:") {
+            guard let colonIndex = line.firstIndex(of: ":") else { continue }
+            let value = line[line.index(after: colonIndex)...].trimmingCharacters(in: .whitespaces)
+            return Int(value)
+        }
+        return nil
     }
     
     /**
@@ -260,9 +259,8 @@ class ThinkingProxy {
             sendError(to: connection, statusCode: 400, message: "Invalid request format - no body separator")
             return
         }
-        
-        let bodyStart = requestString.distance(from: requestString.startIndex, to: bodyStartRange.upperBound)
-        let bodyString = String(requestString[requestString.index(requestString.startIndex, offsetBy: bodyStart)...])
+
+        let bodyString = String(requestString[bodyStartRange.upperBound...])
         
         // Redirect Amp CLI login directly to ampcode.com to preserve auth state cookies
         if path.starts(with: "/auth/cli-login") || path.starts(with: "/api/auth/cli-login") {
@@ -928,93 +926,91 @@ class ThinkingProxy {
     private func receiveAmpResponse(from targetConnection: NWConnection, originalConnection: NWConnection) {
         targetConnection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
             guard let self = self else { return }
-            
+
             if let error = error {
                 NSLog("[ThinkingProxy] Receive Amp response error: \(error)")
                 targetConnection.cancel()
                 originalConnection.cancel()
                 return
             }
-            
-            if let data = data, !data.isEmpty {
-                // Convert to string to rewrite headers
-                if var responseString = String(data: data, encoding: .utf8) {
-                    // Rewrite Location headers to prepend /api/
-                    responseString = responseString.replacingOccurrences(
-                        of: "\r\nlocation: /",
-                        with: "\r\nlocation: /api/",
-                        options: .caseInsensitive
-                    )
-                    responseString = responseString.replacingOccurrences(
-                        of: "\r\nLocation: /",
-                        with: "\r\nLocation: /api/"
-                    )
 
-                    // Rewrite absolute Location headers to keep browser on localhost proxy
-                    responseString = responseString.replacingOccurrences(
-                        of: "\r\nLocation: https://ampcode.com/",
-                        with: "\r\nLocation: /api/",
-                        options: .caseInsensitive
-                    )
-                    responseString = responseString.replacingOccurrences(
-                        of: "\r\nLocation: http://ampcode.com/",
-                        with: "\r\nLocation: /api/",
-                        options: .caseInsensitive
-                    )
-
-                    // Rewrite cookie domain so browser accepts cookies from localhost
-                    responseString = responseString.replacingOccurrences(
-                        of: "Domain=.ampcode.com",
-                        with: "Domain=localhost",
-                        options: .caseInsensitive
-                    )
-                    responseString = responseString.replacingOccurrences(
-                        of: "Domain=ampcode.com",
-                        with: "Domain=localhost",
-                        options: .caseInsensitive
-                    )
-                    
-                    if let modifiedData = responseString.data(using: .utf8) {
-                        originalConnection.send(content: modifiedData, completion: .contentProcessed({ sendError in
-                            if let sendError = sendError {
-                                NSLog("[ThinkingProxy] Send Amp response error: \(sendError)")
-                            }
-                            
-                            if isComplete {
-                                targetConnection.cancel()
-                                originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
-                                    originalConnection.cancel()
-                                }))
-                            } else {
-                                // Continue receiving more data
-                                self.receiveAmpResponse(from: targetConnection, originalConnection: originalConnection)
-                            }
-                        }))
-                    }
-                } else {
-                    // Not UTF-8, forward as-is
-                    originalConnection.send(content: data, completion: .contentProcessed({ sendError in
-                        if let sendError = sendError {
-                            NSLog("[ThinkingProxy] Send Amp response error: \(sendError)")
-                        }
-                        
-                        if isComplete {
-                            targetConnection.cancel()
-                            originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
-                                originalConnection.cancel()
-                            }))
-                        } else {
-                            self.receiveAmpResponse(from: targetConnection, originalConnection: originalConnection)
-                        }
-                    }))
+            guard let data = data, !data.isEmpty else {
+                if isComplete {
+                    self.finishStreaming(target: targetConnection, client: originalConnection)
                 }
-            } else if isComplete {
-                targetConnection.cancel()
-                originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
-                    originalConnection.cancel()
-                }))
+                return
             }
+
+            // Pick what to forward: rewritten UTF-8 bytes if possible, else original.
+            // If we successfully decoded UTF-8 but failed to re-encode (unreachable
+            // in practice), match the original behavior of dropping the chunk.
+            let outboundData: Data
+            if let responseString = String(data: data, encoding: .utf8) {
+                guard let modifiedData = self.rewriteAmpResponseHeaders(in: responseString).data(using: .utf8) else {
+                    return
+                }
+                outboundData = modifiedData
+            } else {
+                outboundData = data
+            }
+
+            originalConnection.send(content: outboundData, completion: .contentProcessed({ sendError in
+                if let sendError = sendError {
+                    NSLog("[ThinkingProxy] Send Amp response error: \(sendError)")
+                }
+
+                if isComplete {
+                    self.finishStreaming(target: targetConnection, client: originalConnection)
+                } else {
+                    self.receiveAmpResponse(from: targetConnection, originalConnection: originalConnection)
+                }
+            }))
         }
+    }
+
+    /// Rewrites Amp response headers so browser flows continue to work through the
+    /// local proxy: prepends `/api/` to relative Location values, strips the
+    /// `https://ampcode.com/` host from absolute Location values, and rewrites
+    /// `Domain=` cookie attributes to `localhost`.
+    private func rewriteAmpResponseHeaders(in responseString: String) -> String {
+        var result = responseString
+
+        // Rewrite Location headers to prepend /api/
+        result = result.replacingOccurrences(
+            of: "\r\nlocation: /",
+            with: "\r\nlocation: /api/",
+            options: .caseInsensitive
+        )
+        result = result.replacingOccurrences(
+            of: "\r\nLocation: /",
+            with: "\r\nLocation: /api/"
+        )
+
+        // Rewrite absolute Location headers to keep browser on localhost proxy
+        result = result.replacingOccurrences(
+            of: "\r\nLocation: https://ampcode.com/",
+            with: "\r\nLocation: /api/",
+            options: .caseInsensitive
+        )
+        result = result.replacingOccurrences(
+            of: "\r\nLocation: http://ampcode.com/",
+            with: "\r\nLocation: /api/",
+            options: .caseInsensitive
+        )
+
+        // Rewrite cookie domain so browser accepts cookies from localhost
+        result = result.replacingOccurrences(
+            of: "Domain=.ampcode.com",
+            with: "Domain=localhost",
+            options: .caseInsensitive
+        )
+        result = result.replacingOccurrences(
+            of: "Domain=ampcode.com",
+            with: "Domain=localhost",
+            options: .caseInsensitive
+        )
+
+        return result
     }
 
     /**
@@ -1039,11 +1035,9 @@ class ThinkingProxy {
                 let excludedHeaders: Set<String> = ["content-length", "host", "transfer-encoding"]
 
                 for (name, value) in headers {
-                    let lowercasedName = name.lowercased()
-                    if excludedHeaders.contains(lowercasedName) {
-                        continue
+                    if !excludedHeaders.contains(name.lowercased()) {
+                        forwardedRequest += "\(name): \(value)\r\n"
                     }
-                    forwardedRequest += "\(name): \(value)\r\n"
                 }
 
                 // Override Host header
@@ -1101,17 +1095,17 @@ class ThinkingProxy {
      */
     private func streamNextChunk(from targetConnection: NWConnection,
                                  to originalConnection: NWConnection,
-                                 rewriteState: AmpProviderRewriteState? = nil) {
+                                 rewriteState: AmpProviderRewriteState?) {
         targetConnection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
             guard let self = self else { return }
-            
+
             if let error = error {
                 NSLog("[ThinkingProxy] Receive response error: \(error)")
                 targetConnection.cancel()
                 originalConnection.cancel()
                 return
             }
-            
+
             if let data = data, !data.isEmpty {
                 var outboundData = data
                 if let rewriteState {
@@ -1128,13 +1122,9 @@ class ThinkingProxy {
                     if let sendError = sendError {
                         NSLog("[ThinkingProxy] Send response error: \(sendError)")
                     }
-                    
+
                     if isComplete {
-                        targetConnection.cancel()
-                        // Always close client connection - no keep-alive/pipelining support
-                        originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
-                            originalConnection.cancel()
-                        }))
+                        self.finishStreaming(target: targetConnection, client: originalConnection)
                     } else {
                         // Schedule next iteration of the streaming loop
                         self.streamNextChunk(from: targetConnection, to: originalConnection, rewriteState: rewriteState)
@@ -1157,6 +1147,18 @@ class ThinkingProxy {
                 }
             }
         }
+    }
+
+    /**
+     Cancels the target connection and signals end-of-stream to the client before
+     cancelling it as well. Safe to call even if `target` has already been
+     cancelled — `NWConnection.cancel()` is idempotent.
+     */
+    private func finishStreaming(target: NWConnection, client: NWConnection) {
+        target.cancel()
+        client.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
+            client.cancel()
+        }))
     }
     
     /**
@@ -1300,35 +1302,32 @@ class ThinkingProxy {
     private func receiveCursorResponse(from targetConnection: NWConnection, originalConnection: NWConnection) {
         targetConnection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
             guard let self = self else { return }
-            
+
             if let error = error {
                 NSLog("[ThinkingProxy] Receive Cursor response error: \(error)")
                 targetConnection.cancel()
                 originalConnection.cancel()
                 return
             }
-            
-            if let data = data, !data.isEmpty {
-                originalConnection.send(content: data, completion: .contentProcessed({ sendError in
-                    if let sendError = sendError {
-                        NSLog("[ThinkingProxy] Send Cursor response error: \(sendError)")
-                    }
-                    
-                    if isComplete {
-                        targetConnection.cancel()
-                        originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
-                            originalConnection.cancel()
-                        }))
-                    } else {
-                        self.receiveCursorResponse(from: targetConnection, originalConnection: originalConnection)
-                    }
-                }))
-            } else if isComplete {
-                targetConnection.cancel()
-                originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
-                    originalConnection.cancel()
-                }))
+
+            guard let data = data, !data.isEmpty else {
+                if isComplete {
+                    self.finishStreaming(target: targetConnection, client: originalConnection)
+                }
+                return
             }
+
+            originalConnection.send(content: data, completion: .contentProcessed({ sendError in
+                if let sendError = sendError {
+                    NSLog("[ThinkingProxy] Send Cursor response error: \(sendError)")
+                }
+
+                if isComplete {
+                    self.finishStreaming(target: targetConnection, client: originalConnection)
+                } else {
+                    self.receiveCursorResponse(from: targetConnection, originalConnection: originalConnection)
+                }
+            }))
         }
     }
 }


### PR DESCRIPTION
Net **-143 lines** across 10 Swift files, produced by 5 parallel `code-simplifier` subagents (one slice per agent, no file overlap) and reviewed by `code-reviewer` before commit.

### What changed
- **ThinkingProxy.swift** — extracted `parseContentLength`, `finishStreaming`, and `rewriteAmpResponseHeaders` helpers; flattened deeply nested if/let chains; consolidated duplicate send branches in `receiveAmpResponse`. The surgical string-insert JSON parser is untouched.
- **SettingsView.swift** — added a `pointingHandCursor(enabled:)` view extension and a `providerServiceRow` helper to remove six copy-pasted hover blocks and five 14-argument `ServiceRow` call sites; deleted dead `@State authResultSuccess` and an unreachable `.cursor` switch case.
- **ServerManager.swift / AppDelegate.swift** — removed unused `OutputCapture` class and `notificationPermissionGranted`; extracted `bundledBinaryPath`, `stopServersIfRunning`, `updateStatusBarIcon`, and `removeThemeObserver`; introduced `MenuTag` and `menuBarIconSize` constants.
- **DroidProxyModelCatalog.swift** — dropped unused level constants (`minimal`, `geminiProLevels`, `geminiFlashLevels`, `cursorLevels`, `kimiLevels`, etc.); inlined trivial single-use level arrays. All required `settingsEntry` reasoning fields preserved.
- **OAuthUsageTracker.swift** — extracted `makeClaudeUsageRequest`, `successAccount`, and `retryClaudeUsageAfterRefresh`; replaced the for-loop initial-account build with `map` + `loadingPlaceholder`. Upstream-JSON parsing left exactly as-is.
- **AuthStatus.swift / AuthDirectoryMonitor.swift / IconCatalog.swift / AppPreferences.swift** — extracted `parseAccount`, `parseExpiry`, `emptyAccounts` helpers; hoisted `scheduleRefresh` to drop the nested `[weak self]` capture; replaced manual `lock/unlock` pairs with `readCache`/`writeCache` helpers using `defer`; tightened the `secretKey` accessor.

### What is preserved (constraint check)
- ThinkingProxy continues to use surgical string-insert JSON edits — no `JSONSerialization.data` round-trips were introduced (Anthropic prompt cache key ordering intact).
- Anthropic-Beta header rewriting, GPT 5.3-codex / 5.4 / 5.5 fast-mode `service_tier=priority` injection, Gemini `/v1/responses` → `/v1/chat/completions` rewrite, Amp / Cursor routing, and the `REQUEST REASONING` debug log all behave exactly as before.
- `NotificationNames` constants (`serverStatusChanged`, `authDirectoryChanged`) unchanged.
- `AppPreferences` keys (fast-mode toggles, `allowRemote`, `secretKey`, `oledTheme`, `backgroundOpacity`, `verboseLogging`) unchanged — none added, none removed.
- `DroidProxyModelDefinition` settings entries still carry `levels`, `defaultLevelValue`, and `settingsEntry` reasoning metadata for every model.
- `AuthManager` still enforces the last-enabled-account-per-provider guard.
- All logging still uses `NSLog`. Local backend still bound to `127.0.0.1:8318`.

### Verification
- `swift build` from `src/` compiles cleanly with no new warnings.
- `code-reviewer` subagent verdict: **APPROVE_WITH_NITS** (nits were style-only, non-blocking).

Out of scope per session: `website/` directory was excluded. No tests in this repo to run.