### PR TITLE
feat: switch Claude Opus 4.7 to 4.8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,12 +71,12 @@ What it still does today:
 
 What it no longer does (removed in the Droid-CLI-thinking refactor):
 
-- No Claude adaptive thinking injection (Opus 4.7 / 4.6 / Sonnet 4.6 — `thinking` + `output_config`)
+- No Claude adaptive thinking injection (Opus 4.8 / 4.6 / Sonnet 4.6 — `thinking` + `output_config`)
 - No Opus 4.5 classic `thinking.budget_tokens` injection
 - No Codex `reasoning.effort` injection
 - No Gemini `generationConfig.thinkingConfig` injection
 - No Kimi `reasoning_effort` injection
-- No `claude-opus-4-7(high)` / `gpt-5.2(xhigh)` etc. “advanced variant” suffix parsing — every level now ships in the single base entry via Droid CLI metadata
+- No `claude-opus-4-8(high)` / `gpt-5.2(xhigh)` etc. “advanced variant” suffix parsing — every level now ships in the single base entry via Droid CLI metadata
 - No Max Budget Mode override
 
 ### Amp routing

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ All releases are code-signed and notarized by Apple. Existing installs auto-upda
 ## Features
 
 - **One-click OAuth auth** -- Claude Code, Codex, Gemini, and Kimi login launched from the Settings window, with credential monitoring and automatic OAuth token refresh.
-- **Per-model reasoning/effort controls** -- Configure Opus 4.7, Sonnet 4.6, GPT 5.2, GPT 5.3 Codex, GPT 5.4, GPT 5.5, Gemini 3.1 Pro, Gemini 3 Flash, and Kimi K2.6 directly from the Settings window. Also supports `fast` mode for gpt models.
-- **Max Budget Mode** -- Nuclear launch button that forces maximum reasoning on Opud/Sonnet 4.6 requests: classic extended thinking with `budget_tokens: 63999`, `max_tokens: 64000`, and `effort: max`. Opus 4.7 does not need this override. Full thinking power for Sonnet, your quota's problem.
+- **Per-model reasoning/effort controls** -- Configure Opus 4.8, Sonnet 4.6, GPT 5.2, GPT 5.3 Codex, GPT 5.4, GPT 5.5, Gemini 3.1 Pro, Gemini 3 Flash, and Kimi K2.6 directly from the Settings window. Also supports `fast` mode for gpt models.
+- **Max Budget Mode** -- Nuclear launch button that forces maximum reasoning on Opud/Sonnet 4.6 requests: classic extended thinking with `budget_tokens: 63999`, `max_tokens: 64000`, and `effort: max`. Opus 4.8 does not need this override. Full thinking power for Sonnet, your quota's problem.
 - **Usage tracking** -- Claude and Codex OAuth quota windows (5-hour + weekly) rendered in the **OAuth Quota Usage** section of the Settings window. Fetched directly from each provider's OAuth API (no `codex` CLI dependency) and refreshed on demand via the inline refresh button.
 
 <p align="center">

--- a/SETUP.md
+++ b/SETUP.md
@@ -13,12 +13,12 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
 ```json
 "customModels": [
     {
-      "model": "claude-opus-4-7",
-      "id": "custom:droidproxy:opus-4-7",
+      "model": "claude-opus-4-8",
+      "id": "custom:droidproxy:opus-4-8",
       "index": 0,
       "baseUrl": "http://localhost:8317",
       "apiKey": "dummy-not-used",
-      "displayName": "DroidProxy: Opus 4.7",
+      "displayName": "DroidProxy: Opus 4.8",
       "maxOutputTokens": 128000,
       "noImageSupport": false,
       "provider": "anthropic"
@@ -109,7 +109,7 @@ Use the standard Claude and Codex model aliases in the `model` field. Claude ent
 
 1. Open DroidProxy Settings
 2. Set the desired effort:
-   - Opus 4.7: `low`, `medium`, `high`, `xhigh`, or `max`
+   - Opus 4.8: `low`, `medium`, `high`, `xhigh`, or `max`
    - Sonnet 4.6: `low`, `medium`, `high`, or `max`
    - GPT 5.2: `low`, `medium`, `high`, or `xhigh`
    - GPT 5.3 Codex: `low`, `medium`, `high`, or `xhigh`

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -97,9 +97,9 @@ enum DroidProxyModelCatalog {
     static var definitions: [DroidProxyModelDefinition] {
         var list = [
             DroidProxyModelDefinition(
-                baseModel: "claude-opus-4-7",
-                idSlug: "opus-4-7",
-                displayName: "Opus 4.7",
+                baseModel: "claude-opus-4-8",
+                idSlug: "opus-4-8",
+                displayName: "Opus 4.8",
                 maxOutputTokens: 128000,
                 provider: "anthropic",
                 providerKey: "claude",

--- a/website/src/components/InstallSection.tsx
+++ b/website/src/components/InstallSection.tsx
@@ -4,12 +4,12 @@ import { ArrowRightIcon } from './icons'
 const codePlain = `// What "Apply" writes for you — no need to touch this yourself.
 "customModels": [
   {
-    "model": "claude-opus-4-7",
-    "id": "custom:droidproxy:opus-4-7",
+    "model": "claude-opus-4-8",
+    "id": "custom:droidproxy:opus-4-8",
     "index": 0,
     "baseUrl": "http://localhost:8317",
     "apiKey": "***",
-    "displayName": "DroidProxy: Opus 4.7",
+    "displayName": "DroidProxy: Opus 4.8",
     "maxOutputTokens": 128000,
     "provider": "anthropic"
   },
@@ -49,12 +49,12 @@ const codePlain = `// What "Apply" writes for you — no need to touch this your
 const codeHtml = `<span class="c">// What "Apply" writes for you — no need to touch this yourself.</span>
 <span class="k">"customModels"</span>: [
   {
-    <span class="k">"model"</span>: <span class="s">"claude-opus-4-7"</span>,
-    <span class="k">"id"</span>: <span class="s">"custom:droidproxy:opus-4-7"</span>,
+    <span class="k">"model"</span>: <span class="s">"claude-opus-4-8"</span>,
+    <span class="k">"id"</span>: <span class="s">"custom:droidproxy:opus-4-8"</span>,
     <span class="k">"index"</span>: <span class="n">0</span>,
     <span class="k">"baseUrl"</span>: <span class="s">"http://localhost:8317"</span>,
     <span class="k">"apiKey"</span>: <span class="s">"***"</span>,
-    <span class="k">"displayName"</span>: <span class="s">"DroidProxy: Opus 4.7"</span>,
+    <span class="k">"displayName"</span>: <span class="s">"DroidProxy: Opus 4.8"</span>,
     <span class="k">"maxOutputTokens"</span>: <span class="n">128000</span>,
     <span class="k">"provider"</span>: <span class="s">"anthropic"</span>
   },
@@ -137,7 +137,7 @@ export default function InstallSection() {
               <span className="step-n">03</span>
               <div>
                 <h4>Click <em style={{ fontStyle: 'normal', color: 'var(--accent)' }}>Apply Factory Models</em></h4>
-                <p>One click adds DroidProxy's models to your Factory Droid setup. Restart your Droid session — when you pick "DroidProxy: Opus 4.7" or any of the others, your subscription handles the bill.</p>
+                <p>One click adds DroidProxy's models to your Factory Droid setup. Restart your Droid session — when you pick "DroidProxy: Opus 4.8" or any of the others, your subscription handles the bill.</p>
               </div>
             </div>
 

--- a/website/src/components/MaxModeSection.tsx
+++ b/website/src/components/MaxModeSection.tsx
@@ -13,7 +13,7 @@ export default function MaxModeSection() {
             <dd>Tough debugging, big refactors, deep architecture questions</dd>
             <dt>Trade-off</dt>
             <dd>Burns subscription quota faster — but it's still your subscription, not metered Factory tokens</dd>
-            <dt>Opus 4.7</dt>
+            <dt>Opus 4.8</dt>
             <dd>Already runs adaptive thinking by default — no toggle needed</dd>
           </dl>
         </div>

--- a/website/src/components/ModelsSection.tsx
+++ b/website/src/components/ModelsSection.tsx
@@ -1,8 +1,8 @@
 const models = [
   {
     icon: '/assets/icon-claude.png',
-    name: 'Claude Opus 4.7',
-    id: 'opus-4-7',
+    name: 'Claude Opus 4.8',
+    id: 'opus-4-8',
     levels: ['low', 'medium', 'high', 'xhigh', 'max'],
     max: '128,000',
     provider: 'Anthropic',

--- a/website/src/components/UseCasesSection.tsx
+++ b/website/src/components/UseCasesSection.tsx
@@ -10,7 +10,7 @@ const cases = [
   {
     tag: '02 — Same Droid',
     title: 'Nothing about Factory Droid changes.',
-    body: 'DroidProxy installs custom models in your Factory client with one click. Pick "DroidProxy: Opus 4.7" instead of the default — same UI, same agent, same models. Your subscription handles the bill.',
+    body: 'DroidProxy installs custom models in your Factory client with one click. Pick "DroidProxy: Opus 4.8" instead of the default — same UI, same agent, same models. Your subscription handles the bill.',
     footLabel: 'Setup',
     footValue: 'install · sign in · apply',
     footRight: '1 click',
@@ -18,7 +18,7 @@ const cases = [
   {
     tag: '03 — Pick your lab',
     title: 'Mix and match Claude, ChatGPT & Gemini.',
-    body: 'Got a Claude Pro plan? Use Opus 4.7 and Sonnet 4.6. ChatGPT Plus? Run GPT-5 inside Droid. Gemini Advanced? Same. Sign in to whichever ones you have — the rest just stay disabled.',
+    body: 'Got a Claude Pro plan? Use Opus 4.8 and Sonnet 4.6. ChatGPT Plus? Run GPT-5 inside Droid. Gemini Advanced? Same. Sign in to whichever ones you have — the rest just stay disabled.',
     footLabel: 'Models',
     footValue: '7 supported · all optional',
     footRight: '3 labs',


### PR DESCRIPTION
## Summary
Switches the Claude Opus 4.7 model to the new Opus 4.8 model definition while preserving all existing custom properties (defaultLevelValue, levels, kind, maxOutputTokens, etc.) as requested.

## Changes
- Updated `src/Sources/DroidProxyModelCatalog.swift` definitions to use `claude-opus-4-8` (and `opus-4-8` slug / `Opus 4.8` display name).
- Updated `SETUP.md` and `README.md` documentation to reference Opus 4.8.
- Updated website copy and examples in `website/src/components/InstallSection.tsx`, `website/src/components/ModelsSection.tsx`, `website/src/components/MaxModeSection.tsx`, and `website/src/components/UseCasesSection.tsx`.
- Tested and verified that `swift build` compiles cleanly.
- Updated `AGENTS.md` specifications.