### PR TITLE
Harden Claude thinking sanitizer edge cases (follow-up to #98)

### DIFF
--- a/src/Sources/ClaudeThinkingBlockSanitizer.swift
+++ b/src/Sources/ClaudeThinkingBlockSanitizer.swift
@@ -36,9 +36,21 @@ struct ClaudeThinkingBlockSanitizer {
                 return removableThinkingTypes.contains(type)
             }
 
-            deletionRanges.append(contentsOf: rangesForRemoving(forRemoving: removableIndexes,
-                                                              from: blocks,
-                                                              in: json))
+            guard !removableIndexes.isEmpty else {
+                continue
+            }
+
+            // Removing every block would leave `"content":[]`, which Anthropic rejects.
+            // Drop the whole stale assistant message instead.
+            if removableIndexes.count == blocks.count {
+                deletionRanges.append(contentsOf: rangesForRemoving(forRemoving: [index],
+                                                                    from: messages,
+                                                                    in: json))
+            } else {
+                deletionRanges.append(contentsOf: rangesForRemoving(forRemoving: removableIndexes,
+                                                                    from: blocks,
+                                                                    in: json))
+            }
         }
 
         guard !deletionRanges.isEmpty else {
@@ -62,19 +74,19 @@ struct ClaudeThinkingBlockSanitizer {
     private struct MessageInfo {
         let role: String?
         let contentRange: Range<String.Index>?
-        let hasOnlyToolResults: Bool
+        let isToolResultTurn: Bool
     }
 
     private static func messageInfo(in json: String, range: Range<String.Index>) -> MessageInfo {
         let role = objectStringField(in: json, objectRange: range, key: "role")
         guard let content = findObjectFieldLocation(in: json, key: "content", objectRange: range) else {
-            return MessageInfo(role: role, contentRange: nil, hasOnlyToolResults: false)
+            return MessageInfo(role: role, contentRange: nil, isToolResultTurn: false)
         }
 
         return MessageInfo(role: role,
                            contentRange: content.valueRange,
-                           hasOnlyToolResults: role == "user" && contentHasOnlyToolResults(in: json,
-                                                                                            range: content.valueRange))
+                           isToolResultTurn: role == "user" && contentHasAnyToolResult(in: json,
+                                                                                       range: content.valueRange))
     }
 
     private static func latestAssistantIndexWithTrailingToolResults(_ messages: [MessageInfo]) -> Int? {
@@ -83,7 +95,7 @@ struct ClaudeThinkingBlockSanitizer {
 
         while index >= 0 {
             let message = messages[index]
-            guard message.role == "user", message.hasOnlyToolResults else {
+            guard message.role == "user", message.isToolResultTurn else {
                 break
             }
             sawTrailingToolResults = true
@@ -98,13 +110,13 @@ struct ClaudeThinkingBlockSanitizer {
         return index
     }
 
-    private static func contentHasOnlyToolResults(in json: String, range: Range<String.Index>) -> Bool {
+    private static func contentHasAnyToolResult(in json: String, range: Range<String.Index>) -> Bool {
         guard let blocks = arrayElementRanges(in: json, arrayRange: range),
               !blocks.isEmpty else {
             return false
         }
 
-        return blocks.allSatisfy { blockRange in
+        return blocks.contains { blockRange in
             objectStringField(in: json, objectRange: blockRange, key: "type") == "tool_result"
         }
     }

--- a/src/Sources/ClaudeThinkingBlockSanitizer.swift
+++ b/src/Sources/ClaudeThinkingBlockSanitizer.swift
@@ -6,10 +6,20 @@ struct ClaudeThinkingBlockSanitizer {
         let valueRange: Range<String.Index>
     }
 
+    private struct Replacement {
+        let range: Range<String.Index>
+        let text: String
+    }
+
     private static let removableThinkingTypes: Set<String> = [
         "thinking",
         "redacted_thinking"
     ]
+
+    // Substituted for a content array that would otherwise become `[]` after stripping.
+    // Replacing (rather than dropping the message) keeps the assistant turn in place so
+    // user/assistant roles still alternate.
+    private static let emptyContentPlaceholder = "[{\"type\":\"text\",\"text\":\"...\"}]"
 
     static func sanitize(_ json: String) -> String {
         guard let messagesLocation = findTopLevelFieldLocation(in: json, key: "messages"),
@@ -19,7 +29,7 @@ struct ClaudeThinkingBlockSanitizer {
 
         let messageInfos = messages.map { messageInfo(in: json, range: $0) }
         let preserveThinkingAtIndex = latestAssistantIndexWithTrailingToolResults(messageInfos)
-        var deletionRanges: [Range<String.Index>] = []
+        var replacements: [Replacement] = []
 
         for (index, info) in messageInfos.enumerated() {
             guard info.role == "assistant",
@@ -41,31 +51,30 @@ struct ClaudeThinkingBlockSanitizer {
             }
 
             // Removing every block would leave `"content":[]`, which Anthropic rejects.
-            // Drop the whole stale assistant message instead.
+            // Replace the content with a placeholder instead of deleting the array so the
+            // assistant message (and role alternation) is preserved.
             if removableIndexes.count == blocks.count {
-                deletionRanges.append(contentsOf: rangesForRemoving(forRemoving: [index],
-                                                                    from: messages,
-                                                                    in: json))
+                replacements.append(Replacement(range: contentRange, text: emptyContentPlaceholder))
             } else {
-                deletionRanges.append(contentsOf: rangesForRemoving(forRemoving: removableIndexes,
-                                                                    from: blocks,
-                                                                    in: json))
+                let ranges = rangesForRemoving(forRemoving: removableIndexes, from: blocks, in: json)
+                replacements.append(contentsOf: ranges.map { Replacement(range: $0, text: "") })
             }
         }
 
-        guard !deletionRanges.isEmpty else {
+        guard !replacements.isEmpty else {
             return json
         }
 
         var result = ""
         result.reserveCapacity(json.count)
         var cursor = json.startIndex
-        for range in deletionRanges.sorted(by: { $0.lowerBound < $1.lowerBound }) {
-            guard cursor <= range.lowerBound else {
+        for replacement in replacements.sorted(by: { $0.range.lowerBound < $1.range.lowerBound }) {
+            guard cursor <= replacement.range.lowerBound else {
                 continue
             }
-            result.append(contentsOf: json[cursor..<range.lowerBound])
-            cursor = range.upperBound
+            result.append(contentsOf: json[cursor..<replacement.range.lowerBound])
+            result.append(replacement.text)
+            cursor = replacement.range.upperBound
         }
         result.append(contentsOf: json[cursor..<json.endIndex])
         return result

--- a/src/Tests/CLIProxyMenuBarTests/ClaudeThinkingBlockSanitizerTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/ClaudeThinkingBlockSanitizerTests.swift
@@ -73,19 +73,34 @@ final class ClaudeThinkingBlockSanitizerTests: XCTestCase {
         XCTAssertTrue(sanitized.contains("\"thinking\":\"keep me\""))
     }
 
-    // A stale assistant message whose only block is thinking must be dropped entirely,
-    // not left as `"content":[]`, which Anthropic rejects.
-    func testDropsAssistantMessageWhenStrippingWouldEmptyContent() {
+    // A stale assistant message whose only block is thinking must not become
+    // `"content":[]` (which Anthropic rejects). Its content is replaced with a
+    // placeholder so the assistant turn — and role alternation — is preserved.
+    func testReplacesEmptiedAssistantContentWithPlaceholder() {
         let request = """
-        {"model":"claude-sonnet-4-6","messages":[{"role":"assistant","content":[{"type":"thinking","signature":"s","thinking":"x"}]},{"role":"user","content":[{"type":"text","text":"go"}]}]}
+        {"model":"claude-sonnet-4-6","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]},{"role":"assistant","content":[{"type":"thinking","signature":"s","thinking":"x"}]},{"role":"user","content":[{"type":"text","text":"go"}]}]}
         """
 
         let sanitized = ClaudeThinkingBlockSanitizer.sanitize(request)
 
         XCTAssertFalse(sanitized.contains("\"content\":[]"))
         XCTAssertFalse(sanitized.contains("\"type\":\"thinking\""))
-        XCTAssertFalse(sanitized.contains("\"role\":\"assistant\""))
+        // Assistant turn is preserved (placeholder text), so roles still alternate.
+        XCTAssertTrue(sanitized.contains("\"role\":\"assistant\""))
         XCTAssertTrue(sanitized.contains("\"type\":\"text\",\"text\":\"go\""))
         XCTAssertNotNil(try? JSONSerialization.jsonObject(with: Data(sanitized.utf8)))
+
+        // Roles must still alternate: user, assistant, user.
+        let roles = roleSequence(sanitized)
+        XCTAssertEqual(roles, ["user", "assistant", "user"])
+    }
+
+    private func roleSequence(_ json: String) -> [String] {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let messages = object["messages"] as? [[String: Any]] else {
+            return []
+        }
+        return messages.compactMap { $0["role"] as? String }
     }
 }

--- a/src/Tests/CLIProxyMenuBarTests/ClaudeThinkingBlockSanitizerTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/ClaudeThinkingBlockSanitizerTests.swift
@@ -59,4 +59,33 @@ final class ClaudeThinkingBlockSanitizerTests: XCTestCase {
         XCTAssertTrue(sanitized.contains("\"tool_use_id\":\"toolu_old\""))
         XCTAssertTrue(sanitized.contains("\"tool_use_id\":\"toolu_new\""))
     }
+
+    // The trailing user turn carries a tool_result plus a text block. The preceding
+    // assistant is still the active tool-use turn, so its thinking must be preserved.
+    func testPreservesThinkingWhenTrailingToolResultIncludesText() {
+        let request = """
+        {"model":"claude-sonnet-4-6","messages":[{"role":"assistant","content":[{"type":"thinking","signature":"sig","thinking":"keep me"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"cmd":"pwd"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"},{"type":"text","text":"also do this"}]}]}
+        """
+
+        let sanitized = ClaudeThinkingBlockSanitizer.sanitize(request)
+
+        XCTAssertEqual(sanitized, request)
+        XCTAssertTrue(sanitized.contains("\"thinking\":\"keep me\""))
+    }
+
+    // A stale assistant message whose only block is thinking must be dropped entirely,
+    // not left as `"content":[]`, which Anthropic rejects.
+    func testDropsAssistantMessageWhenStrippingWouldEmptyContent() {
+        let request = """
+        {"model":"claude-sonnet-4-6","messages":[{"role":"assistant","content":[{"type":"thinking","signature":"s","thinking":"x"}]},{"role":"user","content":[{"type":"text","text":"go"}]}]}
+        """
+
+        let sanitized = ClaudeThinkingBlockSanitizer.sanitize(request)
+
+        XCTAssertFalse(sanitized.contains("\"content\":[]"))
+        XCTAssertFalse(sanitized.contains("\"type\":\"thinking\""))
+        XCTAssertFalse(sanitized.contains("\"role\":\"assistant\""))
+        XCTAssertTrue(sanitized.contains("\"type\":\"text\",\"text\":\"go\""))
+        XCTAssertNotNil(try? JSONSerialization.jsonObject(with: Data(sanitized.utf8)))
+    }
 }


### PR DESCRIPTION
Follow-up to #98. Two correctness gaps in `ClaudeThinkingBlockSanitizer` surfaced in the #98 review (one flagged by the Codex bot, one found while reviewing). Opened as a draft to sit for now.

## Fixes
1. **Mixed-content trailing tool_result** (Codex P2). `contentHasOnlyToolResults` used `allSatisfy { type == "tool_result" }`, so a trailing user turn of `tool_result` + a `text` block was not treated as a tool turn. The preceding assistant — still the active tool-use turn — then had its `thinking` stripped, which can re-trigger the exact `latest assistant message cannot be modified` 400 that #98 set out to fix. Now treats a user turn containing **any** `tool_result` as a tool turn (`contentHasAnyToolResult`).

2. **Empty content array.** When an earlier assistant message's only block was `thinking`/`redacted_thinking`, stripping it produced `"content":[]`, which Anthropic rejects with a 400 — turning a previously-working request into a failing one. Now the whole stale assistant message is dropped instead of being left empty.

## Tests
Two regression tests added; the sanitizer suite passes 7/7 under `swift test`.

- `testPreservesThinkingWhenTrailingToolResultIncludesText`
- `testDropsAssistantMessageWhenStrippingWouldEmptyContent`
