### PR TITLE
Strip clustered thinking-merge turns to fix BYOK 400 (#97)

### DIFF
--- a/src/Sources/ClaudeThinkingBlockSanitizer.swift
+++ b/src/Sources/ClaudeThinkingBlockSanitizer.swift
@@ -28,7 +28,25 @@ struct ClaudeThinkingBlockSanitizer {
         }
 
         let messageInfos = messages.map { messageInfo(in: json, range: $0) }
-        let preserveThinkingAtIndex = latestAssistantIndexWithTrailingToolResults(messageInfos)
+        var preserveThinkingAtIndex = latestAssistantIndexWithTrailingToolResults(messageInfos)
+
+        // Droid sometimes squashes several reasoning/tool steps into a single assistant
+        // message, producing a "clustered" layout where every thinking block sits before
+        // every tool_use block (e.g. [thinking, thinking, …, tool_use, tool_use, …]) instead
+        // of the valid interleaved ordering (thinking -> tool_use -> thinking -> tool_use …).
+        // Anthropic rejects that turn with a 400 ("`thinking` … blocks … cannot be modified")
+        // because the signed thinking sequence is out of order — preserving it is exactly what
+        // triggers the failure. When the turn we would otherwise preserve is a clustered merge,
+        // drop the preservation so its thinking is stripped like every other stale turn.
+        // Stripping leaves the tool_use blocks (and the matching tool_result ids) untouched,
+        // which keeps the request valid, and clean interleaved turns are still preserved so the
+        // show-thinking behaviour is unaffected.
+        if let preserve = preserveThinkingAtIndex,
+           let contentRange = messageInfos[preserve].contentRange,
+           isClusteredThinkingMerge(in: json, contentRange: contentRange) {
+            preserveThinkingAtIndex = nil
+        }
+
         var replacements: [Replacement] = []
 
         for (index, info) in messageInfos.enumerated() {
@@ -117,6 +135,38 @@ struct ClaudeThinkingBlockSanitizer {
             return nil
         }
         return index
+    }
+
+    // A "clustered thinking merge" is an assistant turn where two or more thinking
+    // (or redacted_thinking) blocks all appear before the first tool_use block. Valid
+    // extended-thinking turns interleave each thinking block with the tool_use it produced
+    // (thinking -> tool_use -> thinking -> tool_use …); a single leading thinking block
+    // followed by parallel tool_use blocks is also valid. Only the clustered shape — produced
+    // when Droid squashes multiple reasoning/tool steps into one message — reorders the signed
+    // thinking sequence and is rejected by Anthropic. The `>= 2` check keeps the common
+    // single-thinking-then-parallel-tools turn untouched.
+    private static func isClusteredThinkingMerge(in json: String,
+                                                 contentRange: Range<String.Index>) -> Bool {
+        guard let blocks = arrayElementRanges(in: json, arrayRange: contentRange) else {
+            return false
+        }
+
+        var thinkingCount = 0
+        var lastThinkingIndex = -1
+        var firstToolUseIndex = Int.max
+        for (index, block) in blocks.enumerated() {
+            guard let type = objectStringField(in: json, objectRange: block, key: "type") else {
+                continue
+            }
+            if removableThinkingTypes.contains(type) {
+                thinkingCount += 1
+                lastThinkingIndex = index
+            } else if type == "tool_use" {
+                firstToolUseIndex = min(firstToolUseIndex, index)
+            }
+        }
+
+        return thinkingCount >= 2 && firstToolUseIndex != Int.max && lastThinkingIndex < firstToolUseIndex
     }
 
     private static func contentHasAnyToolResult(in json: String, range: Range<String.Index>) -> Bool {

--- a/src/Tests/CLIProxyMenuBarTests/ClaudeThinkingBlockSanitizerTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/ClaudeThinkingBlockSanitizerTests.swift
@@ -95,6 +95,88 @@ final class ClaudeThinkingBlockSanitizerTests: XCTestCase {
         XCTAssertEqual(roles, ["user", "assistant", "user"])
     }
 
+    // Droid sometimes merges several reasoning/tool steps into one assistant message, leaving
+    // every thinking block clustered before every tool_use block. That turn is itself malformed,
+    // so even though it is the latest assistant turn before a tool_result-only user turn it must
+    // NOT be preserved — its thinking has to be stripped. The tool_use blocks (and the matching
+    // tool_result ids) must survive so the request stays valid.
+    func testStripsClusteredThinkingInLatestAssistantTurn() {
+        let request = """
+        {"model":"claude-sonnet-4-6","messages":[{"role":"assistant","content":[{"type":"thinking","signature":"sigA","thinking":"first"},{"type":"thinking","signature":"sigB","thinking":"second"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"cmd":"pwd"}},{"type":"tool_use","id":"toolu_2","name":"Read","input":{"file":"a"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"},{"type":"tool_result","tool_use_id":"toolu_2","content":"ok"}]}]}
+        """
+
+        let sanitized = ClaudeThinkingBlockSanitizer.sanitize(request)
+
+        XCTAssertFalse(sanitized.contains("\"type\":\"thinking\""))
+        XCTAssertFalse(sanitized.contains("\"signature\":\"sigA\""))
+        XCTAssertFalse(sanitized.contains("\"signature\":\"sigB\""))
+        // tool_use blocks and their tool_result references are untouched.
+        XCTAssertTrue(sanitized.contains("\"type\":\"tool_use\",\"id\":\"toolu_1\""))
+        XCTAssertTrue(sanitized.contains("\"type\":\"tool_use\",\"id\":\"toolu_2\""))
+        XCTAssertTrue(sanitized.contains("\"type\":\"tool_result\",\"tool_use_id\":\"toolu_1\""))
+        XCTAssertTrue(sanitized.contains("\"type\":\"tool_result\",\"tool_use_id\":\"toolu_2\""))
+        XCTAssertNotNil(try? JSONSerialization.jsonObject(with: Data(sanitized.utf8)))
+        XCTAssertEqual(roleSequence(sanitized), ["assistant", "user"])
+    }
+
+    // Same clustered shape, but with a text block sitting between the clustered thinking blocks
+    // and the tool_use blocks — mirrors the real failing layout (e.g. [thinking, thinking, text,
+    // tool_use, …]). The interposed text must not stop the clustered turn from being stripped.
+    func testStripsClusteredThinkingWithInterposedTextBlock() {
+        let request = """
+        {"model":"claude-sonnet-4-6","messages":[{"role":"assistant","content":[{"type":"thinking","signature":"sigA","thinking":"first"},{"type":"thinking","signature":"sigB","thinking":"second"},{"type":"text","text":"working on it"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"cmd":"pwd"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}
+        """
+
+        let sanitized = ClaudeThinkingBlockSanitizer.sanitize(request)
+
+        XCTAssertFalse(sanitized.contains("\"type\":\"thinking\""))
+        XCTAssertTrue(sanitized.contains("\"type\":\"text\",\"text\":\"working on it\""))
+        XCTAssertTrue(sanitized.contains("\"type\":\"tool_use\",\"id\":\"toolu_1\""))
+        XCTAssertTrue(sanitized.contains("\"type\":\"tool_result\",\"tool_use_id\":\"toolu_1\""))
+        XCTAssertNotNil(try? JSONSerialization.jsonObject(with: Data(sanitized.utf8)))
+    }
+
+    // redacted_thinking clusters the same way and must also be stripped.
+    func testStripsClusteredRedactedThinkingInLatestAssistantTurn() {
+        let request = """
+        {"model":"claude-sonnet-4-6","messages":[{"role":"assistant","content":[{"type":"redacted_thinking","data":"first"},{"type":"redacted_thinking","data":"second"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"cmd":"pwd"}},{"type":"tool_use","id":"toolu_2","name":"Read","input":{"file":"a"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"},{"type":"tool_result","tool_use_id":"toolu_2","content":"ok"}]}]}
+        """
+
+        let sanitized = ClaudeThinkingBlockSanitizer.sanitize(request)
+
+        XCTAssertFalse(sanitized.contains("\"type\":\"redacted_thinking\""))
+        XCTAssertTrue(sanitized.contains("\"type\":\"tool_use\",\"id\":\"toolu_1\""))
+        XCTAssertTrue(sanitized.contains("\"type\":\"tool_use\",\"id\":\"toolu_2\""))
+        XCTAssertTrue(sanitized.contains("\"type\":\"tool_result\",\"tool_use_id\":\"toolu_2\""))
+        XCTAssertNotNil(try? JSONSerialization.jsonObject(with: Data(sanitized.utf8)))
+    }
+
+    // The 200 case from the report: two thinking blocks that are correctly interleaved with
+    // their tool_use blocks (thinking -> tool_use -> thinking -> tool_use). This is a valid
+    // signed sequence and must be preserved untouched even though it has >= 2 thinking blocks.
+    func testPreservesInterleavedThinkingInLatestAssistantTurn() {
+        let request = """
+        {"model":"claude-sonnet-4-6","messages":[{"role":"assistant","content":[{"type":"thinking","signature":"sigA","thinking":"first"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"cmd":"pwd"}},{"type":"thinking","signature":"sigB","thinking":"second"},{"type":"tool_use","id":"toolu_2","name":"Read","input":{"file":"a"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"},{"type":"tool_result","tool_use_id":"toolu_2","content":"ok"}]}]}
+        """
+
+        let sanitized = ClaudeThinkingBlockSanitizer.sanitize(request)
+
+        XCTAssertEqual(sanitized, request)
+    }
+
+    // A single leading thinking block followed by parallel tool_use blocks is a normal, valid
+    // shape. The `>= 2` thinking guard means it must stay preserved (not mistaken for a cluster).
+    func testPreservesSingleLeadingThinkingBeforeParallelToolUse() {
+        let request = """
+        {"model":"claude-sonnet-4-6","messages":[{"role":"assistant","content":[{"type":"thinking","signature":"sig","thinking":"plan"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"cmd":"pwd"}},{"type":"tool_use","id":"toolu_2","name":"Read","input":{"file":"a"}},{"type":"tool_use","id":"toolu_3","name":"Read","input":{"file":"b"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"},{"type":"tool_result","tool_use_id":"toolu_2","content":"ok"},{"type":"tool_result","tool_use_id":"toolu_3","content":"ok"}]}]}
+        """
+
+        let sanitized = ClaudeThinkingBlockSanitizer.sanitize(request)
+
+        XCTAssertEqual(sanitized, request)
+        XCTAssertTrue(sanitized.contains("\"thinking\":\"plan\""))
+    }
+
     private func roleSequence(_ json: String) -> [String] {
         guard let data = json.data(using: .utf8),
               let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],


### PR DESCRIPTION
## Summary

Fixes the BYOK `400 "thinking … blocks … cannot be modified"` that several users still hit on **v1.8.38** (after #98 / #99), as diagnosed by @tgarrochinho in [issue #97’s comment](https://github.com/anand-92/droidproxy/issues/97#issuecomment-4586581786).

### Root cause

The sanitizer preserves the thinking blocks of the latest assistant turn when it’s followed by `tool_result`-only user turns. But Droid sometimes **merges several reasoning/tool steps into one assistant message**, producing a *clustered* layout where every thinking block sits before every `tool_use` block (e.g. `[thinking ×9, text, tool_use ×19]`) instead of the valid interleaved `thinking → tool_use → thinking → tool_use` order. That turn is itself malformed, so preserving it is exactly what Anthropic rejects. `SANITIZED CLAUDE THINKING BLOCKS` never fires, because the sanitizer correctly classifies it as the "preserve" case — the trouble is that the preserved turn is the broken one.

@tgarrochinho confirmed by replaying real signed blocks that only the **ordering** matters:

| last assistant content order | result |
|---|---|
| `thinking1, tool_use1, thinking2, tool_use2` (interleaved) | 200 |
| `thinking1, thinking2, tool_use1, tool_use2` (clustered) | 400 "cannot be modified" |

Deleting the thinking blocks from a failing turn also flips it back to 200, i.e. Anthropic only requires that whatever thinking is sent is *unmodified* — not that it’s present on an old `tool_use` turn.

### Fix

Right after the preserve index is computed in `ClaudeThinkingBlockSanitizer.sanitize(...)`, gate it on the turn being clean. If the would-be-preserved turn is a **clustered thinking merge** (`>= 2` thinking blocks all positioned before the first `tool_use`), drop the preservation so its thinking is stripped like every other stale turn. Stripping reuses the existing #99 path, which removes only the thinking blocks and leaves the `tool_use` blocks (and the matching `tool_result` ids) intact, so the request stays valid.

- Clean **interleaved** turns are still preserved → the show-thinking hack is unaffected.
- The `>= 2` check leaves a normal **single-thinking-then-parallel-tools** turn untouched.
- Only the broken clustered shape gets stripped.

### Tests

Added coverage in `ClaudeThinkingBlockSanitizerTests`:

- clustered `thinking` / `redacted_thinking` in the latest assistant turn → stripped; `tool_use` + `tool_result` ids preserved; output still valid JSON
- clustered thinking with an interposed `text` block (mirrors the real `[thinking, thinking, text, tool_use]` shape) → stripped
- interleaved 2-thinking turn → preserved unchanged (the 200 row above)
- single leading thinking before parallel `tool_use` → preserved unchanged

All 7 pre-existing sanitizer tests keep their original behavior.

## Test plan

- [ ] `swift test` on macOS (runs `ClaudeThinkingBlockSanitizerTests`)
- [ ] Reproduce a previously-failing clustered turn on a long Opus 4.8 Droid session and confirm it now returns 200
- [ ] Confirm thinking traces still render for normal interleaved turns (show-thinking unaffected)

Implements the fix proposed by @tgarrochinho. Closes #97.
