### PR TITLE
ci: gate factorydroid review behind the droid-review label

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -2,7 +2,8 @@ name: Droid Auto Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    types: [opened, synchronize, labeled]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -10,7 +11,7 @@ concurrency:
 
 jobs:
   droid-review:
-    if: github.event.pull_request.draft == false
+    if: contains(github.event.pull_request.labels.*.name, 'droid-review')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
The factorydroid review workflow (`.github/workflows/droid-review.yml`) previously ran on **every** non-draft PR (`opened`, `ready_for_review`, `reopened`). It now runs **only when the PR is labeled `droid-review`**, mirroring the existing `junie-review.yml` workflow (which gates on the `junie-review` label).

## Changes
- Trigger changed to `pull_request: [opened, synchronize, labeled]` targeting `main`.
- Job gated with `if: contains(github.event.pull_request.labels.*.name, 'droid-review')`.
- Removed the old `draft == false` guard so the label is the sole gate, matching Junie exactly.

## How to use
- Add the **`droid-review`** label to a PR to request a Factory droid review.
- Pushing new commits to an already-labeled PR (`synchronize`) re-runs the review.

## Notes
- I chose the label name **`droid-review`** as the analog to Junie's `junie-review`. If you'd prefer something else (e.g. `factorydroid-review`), say the word and I'll update it.
- If you want draft PRs excluded even when labeled, I can re-add the `draft == false` condition.