### PR TITLE
fix(quota): correct Claude Sonnet usage parsing

### DIFF
--- a/src/Sources/OAuthUsageTracker.swift
+++ b/src/Sources/OAuthUsageTracker.swift
@@ -268,7 +268,9 @@ final class OAuthUsageTracker: ObservableObject {
                   let utilization = numberValue(dict["utilization"]) else {
                 continue
             }
-            let usedPercent = utilization
+            // The Claude API defines 'utilization' as a percentage value in the range [0.0, 100.0]
+            // where 1.0 represents 1% (not 1.0 = 100%). We clamp this value defensively.
+            let usedPercent = max(0.0, min(100.0, utilization))
             let resetsAtStr = dict["resets_at"] as? String
             let resetDate = resetsAtStr.flatMap(parseISO8601Date)
             let resetText = resetDate.map(resetText(for:)) ?? resetsAtStr

--- a/src/Sources/OAuthUsageTracker.swift
+++ b/src/Sources/OAuthUsageTracker.swift
@@ -247,7 +247,7 @@ final class OAuthUsageTracker: ObservableObject {
         )
     }
 
-    nonisolated private static func parseClaudeWindows(_ data: Data) -> [OAuthUsageWindow] {
+    nonisolated static func parseClaudeWindows(_ data: Data) -> [OAuthUsageWindow] {
         guard let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return []
         }
@@ -268,7 +268,7 @@ final class OAuthUsageTracker: ObservableObject {
                   let utilization = numberValue(dict["utilization"]) else {
                 continue
             }
-            let usedPercent = utilization <= 1 ? utilization * 100 : utilization
+            let usedPercent = utilization
             let resetsAtStr = dict["resets_at"] as? String
             let resetDate = resetsAtStr.flatMap(parseISO8601Date)
             let resetText = resetDate.map(resetText(for:)) ?? resetsAtStr

--- a/src/Tests/CLIProxyMenuBarTests/OAuthUsageTrackerTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/OAuthUsageTrackerTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import CLIProxyMenuBar
+
+final class OAuthUsageTrackerTests: XCTestCase {
+    func testParseClaudeWindowsTreatsUtilizationAsPercentForSonnetBucket() throws {
+        let payload = """
+        {
+          "five_hour": {
+            "utilization": 7.0,
+            "resets_at": "2026-06-05T13:00:00.885429+00:00"
+          },
+          "seven_day": {
+            "utilization": 11.0,
+            "resets_at": "2026-06-10T15:59:59.885452+00:00"
+          },
+          "seven_day_sonnet": {
+            "utilization": 1.0,
+            "resets_at": "2026-06-10T16:00:00.885459+00:00"
+          }
+        }
+        """
+
+        let windows = OAuthUsageTracker.parseClaudeWindows(Data(payload.utf8))
+
+        XCTAssertEqual(windows.first(where: { $0.title == "5-hour" })?.usedPercent, 7)
+        XCTAssertEqual(windows.first(where: { $0.title == "Weekly" })?.usedPercent, 11)
+
+        let sonnetWindow = try XCTUnwrap(windows.first(where: { $0.title == "Weekly (Sonnet)" }))
+        XCTAssertEqual(sonnetWindow.usedPercent, 1)
+        XCTAssertEqual(sonnetWindow.remainingPercent, 99)
+    }
+}

--- a/src/Tests/CLIProxyMenuBarTests/OAuthUsageTrackerTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/OAuthUsageTrackerTests.swift
@@ -29,4 +29,52 @@ final class OAuthUsageTrackerTests: XCTestCase {
         XCTAssertEqual(sonnetWindow.usedPercent, 1)
         XCTAssertEqual(sonnetWindow.remainingPercent, 99)
     }
+
+    func testParseClaudeWindowsHandlesEdgeCases() throws {
+        let payload = """
+        {
+          "five_hour": {
+            "utilization": 0.0,
+            "resets_at": "2026-06-05T13:00:00.885429+00:00"
+          },
+          "seven_day": {
+            "utilization": 100.0,
+            "resets_at": "2026-06-10T15:59:59.885452+00:00"
+          },
+          "seven_day_sonnet": {
+            "utilization": -5.0,
+            "resets_at": "2026-06-10T16:00:00.885459+00:00"
+          },
+          "seven_day_opus": {
+            "utilization": 120.0,
+            "resets_at": "2026-06-10T16:00:00.885459+00:00"
+          }
+        }
+        """
+
+        let windows = OAuthUsageTracker.parseClaudeWindows(Data(payload.utf8))
+
+        let fiveHour = try XCTUnwrap(windows.first(where: { $0.title == "5-hour" }))
+        XCTAssertEqual(fiveHour.usedPercent, 0.0)
+        XCTAssertEqual(fiveHour.remainingPercent, 100.0)
+
+        let weekly = try XCTUnwrap(windows.first(where: { $0.title == "Weekly" }))
+        XCTAssertEqual(weekly.usedPercent, 100.0)
+        XCTAssertEqual(weekly.remainingPercent, 0.0)
+
+        // Clamping edge cases
+        let sonnet = try XCTUnwrap(windows.first(where: { $0.title == "Weekly (Sonnet)" }))
+        XCTAssertEqual(sonnet.usedPercent, 0.0)
+        XCTAssertEqual(sonnet.remainingPercent, 100.0)
+
+        let opus = try XCTUnwrap(windows.first(where: { $0.title == "Weekly (Opus)" }))
+        XCTAssertEqual(opus.usedPercent, 100.0)
+        XCTAssertEqual(opus.remainingPercent, 0.0)
+    }
+
+    func testParseClaudeWindowsHandlesMalformedJSON() throws {
+        let malformedPayload = "{ invalid json"
+        let windows = OAuthUsageTracker.parseClaudeWindows(Data(malformedPayload.utf8))
+        XCTAssertTrue(windows.isEmpty)
+    }
 }


### PR DESCRIPTION
## Description

Fix Claude OAuth usage parsing so the Sonnet weekly quota uses Anthropic's percentage-valued `utilization` field directly. Add a regression test for the live failure case where `seven_day_sonnet.utilization = 1.0` should display as `1% used` / `99% left`.

## Related Issue

Closes #118

## Potential Risk & Impact

- This changes only Claude-specific quota parsing in `OAuthUsageTracker.parseClaudeWindows`.
- If Anthropic ever changes `utilization` to fraction semantics for this endpoint, the UI would underreport usage, but the current live API response and Claude Code behavior both indicate percentage semantics.

## How Has This Been Tested?

- `cd src && swift test --filter OAuthUsageTrackerTests`
- `cd src && swift test`
- `cd src && swift build`
- Verified via sanitized live Anthropic OAuth usage response that `seven_day_sonnet.utilization = 1.0`
