### PR TITLE
feat: add Claude Fable 5 model with Opus 4.8 effort parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Added
+- **Claude Fable 5** -- Anthropic's newest flagship (`claude-fable-5`) is registered as Factory custom model `custom:droidproxy:fable-5` with the same effort levels as Opus 4.8 (`low` / `medium` / `high` / `xhigh` / `max`, default `xhigh`) and a 128k output-token ceiling.
 - **Gemini provider support** -- OAuth login, credential monitoring, provider enable/disable, and service icon in Settings UI
 - **Gemini thinking level controls** -- Per-model thinking level pickers for Gemini 3.1 Pro (`low` / `medium` / `high`) and Gemini 3 Flash (`minimal` / `low` / `medium` / `high`)
 - **Gemini Factory custom models** -- `gemini-3.1-pro-preview` and `gemini-3-flash-preview` added to one-click Factory model provisioning

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Each release also ships a `DroidProxy-arm64.zip.sha256` checksum. Unzip and drag
 ## Features
 
 - **One-click OAuth auth** -- Claude Code, Codex, Gemini, and Kimi login launched from the Settings window, with credential monitoring and automatic OAuth token refresh.
-- **Every model, every reasoning level** -- Opus 4.8, Sonnet 4.6, GPT 5.4, GPT 5.5, Gemini 3.1 Pro, Gemini 3 Flash, and Kimi K2.6 are registered as Factory custom models with their full set of native reasoning levels. Reasoning effort is chosen per session from Droid CLI's model selector and forwarded upstream unchanged.
+- **Every model, every reasoning level** -- Fable 5, Opus 4.8, Sonnet 4.6, GPT 5.4, GPT 5.5, Gemini 3.1 Pro, Gemini 3 Flash, and Kimi K2.6 are registered as Factory custom models with their full set of native reasoning levels. Reasoning effort is chosen per session from Droid CLI's model selector and forwarded upstream unchanged.
 - **Fast Mode** -- Optional `service_tier=priority` for GPT 5.4 and GPT 5.5, toggled from the Settings window for lower-latency responses on the OpenAI Responses API.
 - **Usage tracking** -- Claude and Codex OAuth quota windows (5-hour + weekly) rendered in the **OAuth Quota Usage** section of the Settings window. Fetched directly from each provider's OAuth API (no `codex` CLI dependency) and refreshed on demand via the inline refresh button.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -13,9 +13,20 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
 ```json
 "customModels": [
     {
+      "model": "claude-fable-5",
+      "id": "custom:droidproxy:fable-5",
+      "index": 0,
+      "baseUrl": "http://localhost:8317",
+      "apiKey": "dummy-not-used",
+      "displayName": "DroidProxy: Fable 5",
+      "maxOutputTokens": 128000,
+      "noImageSupport": false,
+      "provider": "anthropic"
+    },
+    {
       "model": "claude-opus-4-8",
       "id": "custom:droidproxy:opus-4-8",
-      "index": 0,
+      "index": 1,
       "baseUrl": "http://localhost:8317",
       "apiKey": "dummy-not-used",
       "displayName": "DroidProxy: Opus 4.8",
@@ -26,7 +37,7 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
     {
       "model": "claude-sonnet-4-6",
       "id": "custom:droidproxy:sonnet-4-6",
-      "index": 1,
+      "index": 2,
       "baseUrl": "http://localhost:8317",
       "apiKey": "dummy-not-used",
       "displayName": "DroidProxy: Sonnet 4.6",
@@ -37,7 +48,7 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
     {
       "model": "gpt-5.4",
       "id": "custom:droidproxy:gpt-5.4",
-      "index": 2,
+      "index": 3,
       "baseUrl": "http://localhost:8317/v1",
       "apiKey": "dummy-not-used",
       "displayName": "DroidProxy: GPT 5.4",
@@ -48,7 +59,7 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
     {
       "model": "gpt-5.5",
       "id": "custom:droidproxy:gpt-5.5",
-      "index": 3,
+      "index": 4,
       "baseUrl": "http://localhost:8317/v1",
       "apiKey": "dummy-not-used",
       "displayName": "DroidProxy: GPT 5.5",
@@ -59,7 +70,7 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
     {
       "model": "gemini-3.1-pro-preview",
       "id": "custom:droidproxy:gemini-3.1-pro",
-      "index": 4,
+      "index": 5,
       "baseUrl": "http://localhost:8317",
       "apiKey": "dummy-not-used",
       "displayName": "DroidProxy: Gemini 3.1 Pro",
@@ -70,7 +81,7 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
     {
       "model": "gemini-3-flash-preview",
       "id": "custom:droidproxy:gemini-3-flash",
-      "index": 5,
+      "index": 6,
       "baseUrl": "http://localhost:8317",
       "apiKey": "dummy-not-used",
       "displayName": "DroidProxy: Gemini 3 Flash",
@@ -87,6 +98,7 @@ Use the standard Claude, Codex, and Gemini model aliases in the `model` field. C
 
 Reasoning effort is selected per session in Droid CLI's model picker — DroidProxy registers each model with its native reasoning levels, so the level you pick in Droid is forwarded upstream unchanged. Supported levels per model:
 
+- Fable 5: `low`, `medium`, `high`, `xhigh`, or `max`
 - Opus 4.8: `low`, `medium`, `high`, `xhigh`, or `max`
 - Sonnet 4.6: `low`, `medium`, `high`, or `max`
 - GPT 5.4: `low`, `medium`, `high`, or `xhigh`

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -123,6 +123,18 @@ enum DroidProxyModelCatalog {
     static var definitions: [DroidProxyModelDefinition] {
         var list = [
             DroidProxyModelDefinition(
+                baseModel: "claude-fable-5",
+                idSlug: "fable-5",
+                displayName: "Fable 5",
+                maxOutputTokens: 128000,
+                provider: "anthropic",
+                providerKey: "claude",
+                baseURL: "http://localhost:8317",
+                kind: .claudeAdaptive,
+                levels: claudeAdvancedLevels,
+                defaultLevelValue: "xhigh"
+            ),
+            DroidProxyModelDefinition(
                 baseModel: "claude-opus-4-8",
                 idSlug: "opus-4-8",
                 displayName: "Opus 4.8",

--- a/src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift
@@ -2,6 +2,17 @@ import XCTest
 @testable import CLIProxyMenuBar
 
 final class DroidProxyModelCatalogTests: XCTestCase {
+    func testFable5MatchesOpus48EffortLevels() throws {
+        let fable = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:fable-5"))
+
+        XCTAssertEqual(fable["model"] as? String, "claude-fable-5")
+        XCTAssertEqual(fable["enableThinking"] as? Bool, true)
+        XCTAssertEqual(fable["reasoningEffort"] as? String, "xhigh")
+        XCTAssertEqual(fable["defaultReasoningEffort"] as? String, "xhigh")
+        XCTAssertEqual(fable["supportedReasoningEfforts"] as? [String], ["low", "medium", "high", "xhigh", "max"])
+        XCTAssertEqual(fable["maxOutputTokens"] as? Int, 128000)
+    }
+
     func testSonnet46UsesNativeModelIDAndExposesMax() throws {
         let sonnet = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:sonnet-4-6"))
 

--- a/website/src/components/InstallSection.tsx
+++ b/website/src/components/InstallSection.tsx
@@ -4,9 +4,19 @@ import { ArrowRightIcon } from './icons'
 const codePlain = `// What "Apply" writes for you — no need to touch this yourself.
 "customModels": [
   {
+    "model": "claude-fable-5",
+    "id": "custom:droidproxy:fable-5",
+    "index": 0,
+    "baseUrl": "http://localhost:8317",
+    "apiKey": "***",
+    "displayName": "DroidProxy: Fable 5",
+    "maxOutputTokens": 128000,
+    "provider": "anthropic"
+  },
+  {
     "model": "claude-opus-4-8",
     "id": "custom:droidproxy:opus-4-8",
-    "index": 0,
+    "index": 1,
     "baseUrl": "http://localhost:8317",
     "apiKey": "***",
     "displayName": "DroidProxy: Opus 4.8",
@@ -16,32 +26,32 @@ const codePlain = `// What "Apply" writes for you — no need to touch this your
   {
     "model": "claude-sonnet-4-6",
     "id": "custom:droidproxy:sonnet-4-6",
-    "index": 1,
+    "index": 2,
     "baseUrl": "http://localhost:8317",
     "apiKey": "***",
     "displayName": "DroidProxy: Sonnet 4.6",
     "maxOutputTokens": 64000,
     "provider": "anthropic"
-  },
-  {
-    "model": "gpt-5.5",
-    "id": "custom:droidproxy:gpt-5.5",
-    "index": 4,
-    "baseUrl": "http://localhost:8317/v1",
-    "apiKey": "***",
-    "displayName": "DroidProxy: GPT 5.5",
-    "maxOutputTokens": 128000,
-    "provider": "openai"
   }
-  // + GPT 5.2, GPT 5.3 Codex, GPT 5.4, Gemini, Kimi
+  // + GPT 5.4, GPT 5.5, Gemini, Kimi
 ]`
 
 const codeHtml = `<span class="c">// What "Apply" writes for you — no need to touch this yourself.</span>
 <span class="k">"customModels"</span>: [
   {
+    <span class="k">"model"</span>: <span class="s">"claude-fable-5"</span>,
+    <span class="k">"id"</span>: <span class="s">"custom:droidproxy:fable-5"</span>,
+    <span class="k">"index"</span>: <span class="n">0</span>,
+    <span class="k">"baseUrl"</span>: <span class="s">"http://localhost:8317"</span>,
+    <span class="k">"apiKey"</span>: <span class="s">"***"</span>,
+    <span class="k">"displayName"</span>: <span class="s">"DroidProxy: Fable 5"</span>,
+    <span class="k">"maxOutputTokens"</span>: <span class="n">128000</span>,
+    <span class="k">"provider"</span>: <span class="s">"anthropic"</span>
+  },
+  {
     <span class="k">"model"</span>: <span class="s">"claude-opus-4-8"</span>,
     <span class="k">"id"</span>: <span class="s">"custom:droidproxy:opus-4-8"</span>,
-    <span class="k">"index"</span>: <span class="n">0</span>,
+    <span class="k">"index"</span>: <span class="n">1</span>,
     <span class="k">"baseUrl"</span>: <span class="s">"http://localhost:8317"</span>,
     <span class="k">"apiKey"</span>: <span class="s">"***"</span>,
     <span class="k">"displayName"</span>: <span class="s">"DroidProxy: Opus 4.8"</span>,
@@ -51,24 +61,14 @@ const codeHtml = `<span class="c">// What "Apply" writes for you — no need to 
   {
     <span class="k">"model"</span>: <span class="s">"claude-sonnet-4-6"</span>,
     <span class="k">"id"</span>: <span class="s">"custom:droidproxy:sonnet-4-6"</span>,
-    <span class="k">"index"</span>: <span class="n">1</span>,
+    <span class="k">"index"</span>: <span class="n">2</span>,
     <span class="k">"baseUrl"</span>: <span class="s">"http://localhost:8317"</span>,
     <span class="k">"apiKey"</span>: <span class="s">"***"</span>,
     <span class="k">"displayName"</span>: <span class="s">"DroidProxy: Sonnet 4.6"</span>,
     <span class="k">"maxOutputTokens"</span>: <span class="n">64000</span>,
     <span class="k">"provider"</span>: <span class="s">"anthropic"</span>
-  },
-  {
-    <span class="k">"model"</span>: <span class="s">"gpt-5.5"</span>,
-    <span class="k">"id"</span>: <span class="s">"custom:droidproxy:gpt-5.5"</span>,
-    <span class="k">"index"</span>: <span class="n">4</span>,
-    <span class="k">"baseUrl"</span>: <span class="s">"http://localhost:8317/v1"</span>,
-    <span class="k">"apiKey"</span>: <span class="s">"***"</span>,
-    <span class="k">"displayName"</span>: <span class="s">"DroidProxy: GPT 5.5"</span>,
-    <span class="k">"maxOutputTokens"</span>: <span class="n">128000</span>,
-    <span class="k">"provider"</span>: <span class="s">"openai"</span>
   }
-  <span class="c">// + GPT 5.2, GPT 5.3 Codex, GPT 5.4, Gemini, Kimi</span>
+  <span class="c">// + GPT 5.4, GPT 5.5, Gemini, Kimi</span>
 ]`
 
 export default function InstallSection() {

--- a/website/src/components/ModelsSection.tsx
+++ b/website/src/components/ModelsSection.tsx
@@ -1,6 +1,14 @@
 const models = [
   {
     icon: '/assets/icon-claude.png',
+    name: 'Claude Fable 5',
+    id: 'fable-5',
+    levels: ['low', 'medium', 'high', 'xhigh', 'max'],
+    max: '128,000',
+    provider: 'Anthropic',
+  },
+  {
+    icon: '/assets/icon-claude.png',
     name: 'Claude Opus 4.8',
     id: 'opus-4-8',
     levels: ['low', 'medium', 'high', 'xhigh', 'max'],

--- a/website/src/components/UseCasesSection.tsx
+++ b/website/src/components/UseCasesSection.tsx
@@ -10,7 +10,7 @@ const cases = [
   {
     tag: '02 — Same Droid',
     title: 'Nothing about Factory Droid changes.',
-    body: 'DroidProxy installs custom models in your Factory client with one click. Pick "DroidProxy: Opus 4.8" instead of the default — same UI, same agent, same models. Your subscription handles the bill.',
+    body: 'DroidProxy installs custom models in your Factory client with one click. Pick "DroidProxy: Fable 5" instead of the default — same UI, same agent, same models. Your subscription handles the bill.',
     footLabel: 'Setup',
     footValue: 'install · sign in · apply',
     footRight: '1 click',
@@ -18,9 +18,9 @@ const cases = [
   {
     tag: '03 — Pick your lab',
     title: 'Mix and match Claude, ChatGPT & Gemini.',
-    body: 'Got a Claude Pro plan? Use Opus 4.8 and Sonnet 4.6. ChatGPT Plus? Run GPT-5 inside Droid. Gemini Advanced? Same. Sign in to whichever ones you have — the rest just stay disabled.',
+    body: 'Got a Claude Pro plan? Use Fable 5, Opus 4.8, and Sonnet 4.6. ChatGPT Plus? Run GPT-5 inside Droid. Gemini Advanced? Same. Sign in to whichever ones you have — the rest just stay disabled.',
     footLabel: 'Models',
-    footValue: '7 supported · all optional',
+    footValue: '8 supported · all optional',
     footRight: '3 labs',
   },
 ]


### PR DESCRIPTION
## Summary

Adds Anthropic's new flagship **Claude Fable 5** (`claude-fable-5`, GA June 9, 2026) to the model catalog with the same effort levels as Opus 4.8.

- **Catalog**: new `claude-fable-5` definition (`custom:droidproxy:fable-5`, "DroidProxy: Fable 5") with efforts `low` / `medium` / `high` / `xhigh` / `max`, default `xhigh`, and a 128k output-token ceiling per the release docs
- **Test**: `testFable5MatchesOpus48EffortLevels` asserts the Factory settings entry (model ID, thinking flag, effort list, default, output cap)
- **Docs**: SETUP.md `customModels` example + supported-levels list, README feature list, CHANGELOG `[Unreleased]` entry
- **Website**: models table row, install example in both `codePlain`/`codeHtml` blocks, use-case copy now leads with Fable 5 ("8 supported" models); also fixes the stale `// + GPT 5.2, GPT 5.3 Codex…` comment left over from #117

No proxy changes needed (verified against the Fable 5 release docs):
- Visible-thinking beta rewrite keys on the `claude-` prefix, so Fable 5 inherits it
- The Sonnet max→classic-thinking transform is keyed strictly to `claude-sonnet-4-6` and does not apply
- Refusal responses (`stop_reason: "refusal"`) pass through to Droid untouched
- Claude Mythos 5 deliberately not added (limited release via Project Glasswing, unreachable through subscription OAuth)

## Test plan

- [x] `swift build` — compiles
- [x] `swift test` — 22/22 pass including the new catalog test
- [x] `npx tsc --noEmit` in `website/` — clean
- [ ] Optional: `./dev-relaunch.sh`, Apply Factory models, confirm `custom:droidproxy:fable-5` lands in `~/.factory/settings.json` with all five efforts and `xhigh` default

🤖 Generated with [Claude Code](https://claude.com/claude-code)