### PR TITLE
Rename Droid-facing Fable 5 to Mythos 5

### DIFF
--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -123,9 +123,9 @@ enum DroidProxyModelCatalog {
     static var definitions: [DroidProxyModelDefinition] {
         var list = [
             DroidProxyModelDefinition(
-                baseModel: "claude-fable-5",
-                idSlug: "fable-5",
-                displayName: "Fable 5",
+                baseModel: "claude-mythos-5",
+                idSlug: "mythos-5",
+                displayName: "Mythos 5",
                 maxOutputTokens: 128000,
                 provider: "anthropic",
                 providerKey: "claude",

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -318,6 +318,10 @@ class ThinkingProxy {
 
         if method == "POST" && !bodyString.isEmpty {
             ThinkingProxy.fileLog("INCOMING REQUEST: \(method) \(rewrittenPath)")
+            if let result = rewriteUpstreamModelAlias(jsonString: modifiedBody, fields: requestFields) {
+                modifiedBody = result
+                requestFields = inspectRequestJSONFields(in: modifiedBody)
+            }
             if let result = applySonnetMaxThinking(jsonString: modifiedBody, fields: requestFields) {
                 modifiedBody = result
                 requestFields = inspectRequestJSONFields(in: modifiedBody)
@@ -449,6 +453,14 @@ class ThinkingProxy {
         "cursor-composer-2.5": "composer-2.5"
     ]
 
+    // Upstream model remaps applied to every provider. The droid-facing model
+    // name differs from the model name the upstream API expects, so we rewrite
+    // the `model` field in-place before forwarding (e.g. the Droid-facing
+    // `claude-mythos-5` hits Anthropic as `claude-fable-5`).
+    private static let upstreamModelAliases: [String: String] = [
+        "claude-mythos-5": "claude-fable-5"
+    ]
+
     // Sonnet 4.6 max-thinking. Sonnet's adaptive thinking rejects
     // `output_config.effort:max` upstream (HTTP 400 "level max not supported"),
     // so when Droid selects the `max` effort we convert the request to classic
@@ -524,6 +536,26 @@ class ThinkingProxy {
         } else if let modelLocation = locations["model"] {
             result.insert(contentsOf: ",\"max_tokens\":\(Self.sonnetMaxThinkingMaxTokens)", at: modelLocation.pairRange.upperBound)
         }
+        return result
+    }
+
+    /// Test entry point for the upstream model-alias rewrite.
+    static func rewriteUpstreamModelAlias(in jsonString: String) -> String {
+        let proxy = ThinkingProxy()
+        let fields = proxy.inspectRequestJSONFields(in: jsonString)
+        return proxy.rewriteUpstreamModelAlias(jsonString: jsonString, fields: fields) ?? jsonString
+    }
+
+    private func rewriteUpstreamModelAlias(jsonString: String, fields: RequestJSONFields?) -> String? {
+        guard let model = fields?.model,
+              let modelLocation = fields?.modelLocation,
+              let upstreamModel = Self.upstreamModelAliases[model] else {
+            return nil
+        }
+
+        var result = jsonString
+        result.replaceSubrange(modelLocation.valueRange, with: "\"\(upstreamModel)\"")
+        ThinkingProxy.fileLog("REWRITE MODEL: \(model) -> \(upstreamModel) (upstream alias)")
         return result
     }
 

--- a/src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift
@@ -2,15 +2,23 @@ import XCTest
 @testable import CLIProxyMenuBar
 
 final class DroidProxyModelCatalogTests: XCTestCase {
-    func testFable5MatchesOpus48EffortLevels() throws {
-        let fable = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:fable-5"))
+    func testMythos5MatchesOpus48EffortLevels() throws {
+        let mythos = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:mythos-5"))
 
-        XCTAssertEqual(fable["model"] as? String, "claude-fable-5")
-        XCTAssertEqual(fable["enableThinking"] as? Bool, true)
-        XCTAssertEqual(fable["reasoningEffort"] as? String, "xhigh")
-        XCTAssertEqual(fable["defaultReasoningEffort"] as? String, "xhigh")
-        XCTAssertEqual(fable["supportedReasoningEfforts"] as? [String], ["low", "medium", "high", "xhigh", "max"])
-        XCTAssertEqual(fable["maxOutputTokens"] as? Int, 128000)
+        XCTAssertEqual(mythos["model"] as? String, "claude-mythos-5")
+        XCTAssertEqual(mythos["displayName"] as? String, "DroidProxy: Mythos 5")
+        XCTAssertEqual(mythos["enableThinking"] as? Bool, true)
+        XCTAssertEqual(mythos["reasoningEffort"] as? String, "xhigh")
+        XCTAssertEqual(mythos["defaultReasoningEffort"] as? String, "xhigh")
+        XCTAssertEqual(mythos["supportedReasoningEfforts"] as? [String], ["low", "medium", "high", "xhigh", "max"])
+        XCTAssertEqual(mythos["maxOutputTokens"] as? Int, 128000)
+    }
+
+    func testMythos5RemapsToFable5Upstream() {
+        let body = "{\"model\":\"claude-mythos-5\",\"max_tokens\":1000}"
+        let rewritten = ThinkingProxy.rewriteUpstreamModelAlias(in: body)
+        XCTAssertTrue(rewritten.contains("\"model\":\"claude-fable-5\""))
+        XCTAssertFalse(rewritten.contains("claude-mythos-5"))
     }
 
     func testSonnet46UsesNativeModelIDAndExposesMax() throws {


### PR DESCRIPTION
## Summary

Factory is currently being hit by a data-retention policy issue that causes Fable 5 to fail. As a temporary workaround, we rename the Droid-facing model so it routes around the failure while still calling the same upstream Anthropic model.

- Droid-facing model is now `custom:droidproxy:mythos-5` (`claude-mythos-5`, display "DroidProxy: Mythos 5").
- `ThinkingProxy` remaps `claude-mythos-5` → `claude-fable-5` in the request body before forwarding upstream, so the Anthropic API still receives Fable 5.
- The remap runs first in the POST pipeline as a surgical in-place edit (preserves JSON key ordering for prompt caching), so downstream Claude thinking/header logic still sees a `claude-` model.

## Tests

- `swift build` and `swift test` pass (23 tests).
- Added `testMythos5MatchesOpus48EffortLevels` and `testMythos5RemapsToFable5Upstream`.