### PR TITLE
Add Junie (JetBrains AI) provider

### DIFF
--- a/src/Sources/AuthStatus.swift
+++ b/src/Sources/AuthStatus.swift
@@ -6,6 +6,7 @@ enum ServiceType: String, CaseIterable {
     case antigravity
     case kimi
     case cursor
+    case junie
 
     init?(authFileType: String) {
         switch authFileType.lowercased() {
@@ -19,6 +20,8 @@ enum ServiceType: String, CaseIterable {
             self = .kimi
         case "cursor":
             self = .cursor
+        case "junie":
+            self = .junie
         default:
             return nil
         }
@@ -31,6 +34,7 @@ enum ServiceType: String, CaseIterable {
         case .antigravity: return "Antigravity"
         case .kimi: return "Kimi"
         case .cursor: return "Cursor"
+        case .junie: return "Junie"
         }
     }
 }

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -6,6 +6,7 @@ enum DroidProxyModelKind {
     case kimi
     case antigravity
     case cursor
+    case junie
 }
 
 struct DroidProxyThinkingLevel: Equatable {
@@ -250,6 +251,47 @@ enum DroidProxyModelCatalog {
                 kind: .kimi,
                 levels: [high],
                 defaultLevelValue: "high"
+            ),
+
+            // Junie (JetBrains AI) subscription models. Routed through the antigravity-style
+            // Junie executor in ThinkingProxy, which strips the `junie-` prefix and forwards
+            // to the JetBrains Grazie backend over TLS using the key in junie.json. The
+            // `junie-` prefix keeps these distinct from the OAuth Claude entries above.
+            DroidProxyModelDefinition(
+                baseModel: "junie-claude-sonnet-5",
+                idSlug: "junie-claude-sonnet-5",
+                displayName: "Junie Sonnet 5",
+                maxOutputTokens: 128000,
+                provider: "anthropic",
+                providerKey: "junie",
+                baseURL: "http://localhost:8317",
+                kind: .junie,
+                levels: claudeAdvancedLevels,
+                defaultLevelValue: "xhigh"
+            ),
+            DroidProxyModelDefinition(
+                baseModel: "junie-claude-opus-4-8",
+                idSlug: "junie-claude-opus-4-8",
+                displayName: "Junie Opus 4.8",
+                maxOutputTokens: 128000,
+                provider: "anthropic",
+                providerKey: "junie",
+                baseURL: "http://localhost:8317",
+                kind: .junie,
+                levels: claudeAdvancedLevels,
+                defaultLevelValue: "xhigh"
+            ),
+            DroidProxyModelDefinition(
+                baseModel: "junie-claude-fable-5",
+                idSlug: "junie-claude-fable-5",
+                displayName: "Junie Fable 5",
+                maxOutputTokens: 128000,
+                provider: "anthropic",
+                providerKey: "junie",
+                baseURL: "http://localhost:8317",
+                kind: .junie,
+                levels: claudeAdvancedLevels,
+                defaultLevelValue: "xhigh"
             )
         ]
 

--- a/src/Sources/Resources/icon-junie.svg
+++ b/src/Sources/Resources/icon-junie.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 250 250" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(5.208333,0,0,5.208333,0,0)">
+        <path d="M31.993,16.013L48,16.013L48,18.68C48,37.346 39.997,48 18.668,48L16,48L16,32L18.668,32C27.998,32 32.006,28.007 32.006,18.667L32.006,16L31.993,16.013ZM16,16L0,16L0,32L16,32L16,16ZM32,0L16,0L16,16L32,16L32,0Z" style="fill:rgb(72,224,84);fill-rule:nonzero;"/>
+    </g>
+</svg>

--- a/src/Sources/ServerManager.swift
+++ b/src/Sources/ServerManager.swift
@@ -74,7 +74,8 @@ class ServerManager: ObservableObject {
         .codex: "codex",
         .antigravity: "antigravity",
         .kimi: "kimi",
-        .cursor: "cursor"
+        .cursor: "cursor",
+        .junie: "junie"
     ]
 
     init() {

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -344,6 +344,8 @@ struct SettingsView: View {
     @State private var authResultMessage = ""
     @State private var showingCursorApiKeyAlert = false
     @State private var cursorApiKey = ""
+    @State private var showingJunieApiKeyAlert = false
+    @State private var junieApiKey = ""
     @State private var authDirectoryMonitor: AuthDirectoryMonitor?
     @State private var expandedRowCount = 0
     @State private var factoryModelsInstalled = false
@@ -354,6 +356,7 @@ struct SettingsView: View {
     private let antigravityEffortSelectionColor = Color(red: 0x42/255, green: 0x85/255, blue: 0xF4/255)
     private let kimiEffortSelectionColor = Color(red: 0x00/255, green: 0xBF/255, blue: 0x91/255)
     private let cursorEffortSelectionColor = Color(red: 0x5E/255, green: 0x5C/255, blue: 0xFA/255)
+    private let junieEffortSelectionColor = Color(red: 0x48/255, green: 0xE0/255, blue: 0x54/255)
     private let oledFooterText = Color(red: 0xA8/255, green: 0xA8/255, blue: 0xA8/255)
 
     private var oauthUsageDashboard: some View {
@@ -793,6 +796,13 @@ struct SettingsView: View {
                         toggleTint: kimiEffortSelectionColor
                     )
 
+                    providerServiceRow(
+                        .junie,
+                        iconName: "icon-junie.svg",
+                        toggleTint: junieEffortSelectionColor,
+                        helpText: "Enter your JetBrains Junie API key to use your JetBrains AI subscription for Junie Sonnet 5, Opus 4.8, and Fable 5."
+                    )
+
                     if betaFlag {
                         providerServiceRow(
                             .cursor,
@@ -909,6 +919,15 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) { }
         } message: {
             Text("Please enter your Cursor API Key. It will be saved under ~/.cli-proxy-api/cursor.json.")
+        }
+        .alert("Add Junie API Key", isPresented: $showingJunieApiKeyAlert) {
+            SecureField("Enter Junie Key", text: $junieApiKey)
+            Button("Save") {
+                saveJunieApiKey(junieApiKey)
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Please enter your JetBrains Junie API key. It will be saved under ~/.cli-proxy-api/junie.json.")
         }
     }
 
@@ -1027,6 +1046,12 @@ struct SettingsView: View {
             return
         }
 
+        if serviceType == .junie {
+            junieApiKey = ""
+            showingJunieApiKeyAlert = true
+            return
+        }
+
         authenticatingService = serviceType
         NSLog("[SettingsView] Starting %@ authentication", serviceType.displayName)
         
@@ -1037,6 +1062,7 @@ struct SettingsView: View {
         case .antigravity: command = .antigravityLogin
         case .kimi: command = .kimiLogin
         case .cursor: return // handled by the early-return above; defensive
+        case .junie: return // handled by the early-return above; defensive
         }
         
         serverManager.runAuthCommand(command) { success, output in
@@ -1066,6 +1092,8 @@ struct SettingsView: View {
             return "🌐 Browser opened for Kimi authentication.\n\nPlease complete the login in your browser.\n\nThe app will automatically detect your credentials."
         case .cursor:
             return "✓ Successfully saved Cursor API Key."
+        case .junie:
+            return "✓ Successfully saved Junie API Key."
         }
     }
 
@@ -1097,7 +1125,36 @@ struct SettingsView: View {
             self.showingAuthResult = true
         }
     }
-    
+
+    private func saveJunieApiKey(_ apiKey: String) {
+        guard !apiKey.isEmpty else { return }
+
+        let fileURL = AuthPaths.authDirectory.appendingPathComponent("junie.json")
+        let json: [String: Any] = [
+            "type": "junie",
+            "email": "junie-user",
+            "apiKey": apiKey,
+            "disabled": false
+        ]
+
+        do {
+            try FileManager.default.createDirectory(at: AuthPaths.authDirectory, withIntermediateDirectories: true)
+            let data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])
+            try data.write(to: fileURL)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+            NSLog("[SettingsView] Saved Junie API Key with secure permissions to \(fileURL.path)")
+
+            authManager.checkAuthStatus()
+
+            self.authResultMessage = "✓ Successfully added Junie API Key."
+            self.showingAuthResult = true
+        } catch {
+            NSLog("[SettingsView] Failed to save Junie API Key: \(error.localizedDescription)")
+            self.authResultMessage = "Failed to save Junie API Key: \(error.localizedDescription)"
+            self.showingAuthResult = true
+        }
+    }
+
     private func disconnectAccount(_ account: AuthAccount) {
         let wasRunning = serverManager.isRunning
         

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -337,6 +337,19 @@ class ThinkingProxy {
                 forwardToCursor(method: method, path: rewrittenPath, version: httpVersion, headers: headers, body: modifiedBody, originalConnection: connection)
                 return
             }
+            if isJunieModel(requestFields) {
+                guard isJunieEnabled() else {
+                    NSLog("[ThinkingProxy] Warning: Junie model requested but the provider is disabled in settings.")
+                    sendError(to: connection, statusCode: 400, message: "Junie provider is disabled in DroidProxy settings.")
+                    return
+                }
+                if let result = rewriteJunieModelAlias(jsonString: modifiedBody, fields: requestFields) {
+                    modifiedBody = result
+                    requestFields = inspectRequestJSONFields(in: modifiedBody)
+                }
+                forwardToJunie(method: method, path: rewrittenPath, version: httpVersion, headers: headers, body: modifiedBody, originalConnection: connection)
+                return
+            }
             if let result = processOpenAIFastMode(jsonString: modifiedBody, path: rewrittenPath, fields: requestFields) {
                 modifiedBody = result
                 requestFields = inspectRequestJSONFields(in: modifiedBody)
@@ -1115,6 +1128,166 @@ class ThinkingProxy {
                     self.finishStreaming(target: targetConnection, client: originalConnection)
                 } else {
                     self.receiveCursorResponse(from: targetConnection, originalConnection: originalConnection)
+                }
+            }))
+        }
+    }
+
+    // MARK: - Junie (JetBrains AI) API Proxying
+    //
+    // Junie models are Anthropic models served by the JetBrains Grazie backend. The
+    // bundled CLIProxyAPI has no JetBrains support, so — like Cursor — we forward these
+    // directly over TLS using the permanent API key stored in junie.json. The DroidProxy
+    // model IDs carry a `junie-` prefix (e.g. `junie-claude-sonnet-5`) so they stay
+    // distinct from the OAuth Claude entries; we strip that prefix before forwarding.
+
+    private static let junieHost = "ingrazzio-cloud-prod.labs.jb.gg"
+    private static let junieAgentHeader = "{\"name\":\"junie:cli\",\"version\":\"2144.7\"}"
+
+    private func isJunieModel(_ requestFields: RequestJSONFields?) -> Bool {
+        guard let model = requestFields?.model else {
+            return false
+        }
+        return model.hasPrefix("junie-")
+    }
+
+    private func isJunieEnabled() -> Bool {
+        if let saved = UserDefaults.standard.dictionary(forKey: "enabledProviders") as? [String: Bool] {
+            return saved["junie"] ?? true
+        }
+        return true
+    }
+
+    /// Strips the `junie-` prefix from the request body's `model` field so the
+    /// JetBrains backend receives the real Anthropic model ID (e.g. `claude-sonnet-5`).
+    private func rewriteJunieModelAlias(jsonString: String, fields: RequestJSONFields?) -> String? {
+        guard let model = fields?.model,
+              let modelLocation = fields?.modelLocation,
+              model.hasPrefix("junie-") else {
+            return nil
+        }
+
+        let backendModel = String(model.dropFirst("junie-".count))
+        var result = jsonString
+        result.replaceSubrange(modelLocation.valueRange, with: "\"\(backendModel)\"")
+        ThinkingProxy.fileLog("REWRITE MODEL: \(model) -> \(backendModel) (Junie alias)")
+        return result
+    }
+
+    private func loadJunieApiKey() -> String? {
+        let authDir = AuthPaths.authDirectory
+        guard let files = try? FileManager.default.contentsOfDirectory(at: authDir, includingPropertiesForKeys: nil) else {
+            return nil
+        }
+        for file in files where file.pathExtension == "json" {
+            guard let data = try? Data(contentsOf: file),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let type = json["type"] as? String,
+                  type.lowercased() == "junie",
+                  let apiKey = json["apiKey"] as? String,
+                  !(json["disabled"] as? Bool ?? false) else {
+                continue
+            }
+            return apiKey
+        }
+        return nil
+    }
+
+    private func forwardToJunie(method: String, path: String, version: String, headers: [(String, String)], body: String, originalConnection: NWConnection) {
+        guard let apiKey = loadJunieApiKey() else {
+            NSLog("[ThinkingProxy] Error: No active Junie API key found")
+            sendError(to: originalConnection, statusCode: 401, message: "No active Junie API key found. Please add a Junie key in DroidProxy settings.")
+            return
+        }
+
+        let tlsOptions = NWProtocolTLS.Options()
+        let parameters = NWParameters(tls: tlsOptions, tcp: NWProtocolTCP.Options())
+
+        let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(Self.junieHost), port: 443)
+        let targetConnection = NWConnection(to: endpoint, using: parameters)
+
+        targetConnection.stateUpdateHandler = { [weak self] state in
+            guard let self = self else { return }
+            switch state {
+            case .ready:
+                var forwardedRequest = "\(method) \(path) \(version)\r\n"
+                // Strip client auth / hop-by-hop headers and anything provider-specific
+                // (anthropic-beta / anthropic-version) that the Grazie backend rejects.
+                let excludedHeaders: Set<String> = [
+                    "host", "content-length", "connection", "transfer-encoding",
+                    "authorization", "anthropic-beta", "anthropic-version",
+                    "accept-encoding", "x-api-key"
+                ]
+                for (name, value) in headers {
+                    if !excludedHeaders.contains(name.lowercased()) {
+                        forwardedRequest += "\(name): \(value)\r\n"
+                    }
+                }
+
+                forwardedRequest += "Host: \(Self.junieHost)\r\n"
+                forwardedRequest += "Authorization: Bearer \(apiKey)\r\n"
+                forwardedRequest += "Content-Type: application/json\r\n"
+                forwardedRequest += "Accept-Encoding: identity\r\n"
+                forwardedRequest += "Grazie-Agent: \(Self.junieAgentHeader)\r\n"
+                forwardedRequest += "X-LLM-Model: anthropic\r\n"
+                forwardedRequest += "X-Keep-Path: true\r\n"
+                forwardedRequest += "X-Accept-EAP-License: true\r\n"
+                forwardedRequest += "Connection: close\r\n"
+                forwardedRequest += "Content-Length: \(body.utf8.count)\r\n\r\n"
+                forwardedRequest += body
+
+                if let requestData = forwardedRequest.data(using: .utf8) {
+                    targetConnection.send(content: requestData, completion: .contentProcessed({ error in
+                        if let error = error {
+                            NSLog("[ThinkingProxy] Send error to \(Self.junieHost): \(error)")
+                            targetConnection.cancel()
+                            originalConnection.cancel()
+                        } else {
+                            self.receiveJunieResponse(from: targetConnection, originalConnection: originalConnection)
+                        }
+                    }))
+                }
+
+            case .failed(let error):
+                NSLog("[ThinkingProxy] Connection to \(Self.junieHost) failed: \(error)")
+                self.sendError(to: originalConnection, statusCode: 502, message: "Bad Gateway - Could not connect to \(Self.junieHost)")
+                targetConnection.cancel()
+
+            default:
+                break
+            }
+        }
+
+        targetConnection.start(queue: .global(qos: .userInitiated))
+    }
+
+    private func receiveJunieResponse(from targetConnection: NWConnection, originalConnection: NWConnection) {
+        targetConnection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                NSLog("[ThinkingProxy] Receive Junie response error: \(error)")
+                targetConnection.cancel()
+                originalConnection.cancel()
+                return
+            }
+
+            guard let data = data, !data.isEmpty else {
+                if isComplete {
+                    self.finishStreaming(target: targetConnection, client: originalConnection)
+                }
+                return
+            }
+
+            originalConnection.send(content: data, completion: .contentProcessed({ sendError in
+                if let sendError = sendError {
+                    NSLog("[ThinkingProxy] Send Junie response error: \(sendError)")
+                }
+
+                if isComplete {
+                    self.finishStreaming(target: targetConnection, client: originalConnection)
+                } else {
+                    self.receiveJunieResponse(from: targetConnection, originalConnection: originalConnection)
                 }
             }))
         }


### PR DESCRIPTION
## Summary

Adds **Junie** (JetBrains AI) as a provider, exposing three models: **Junie Sonnet 5**, **Junie Opus 4.8**, and **Junie Fable 5**.

## How it works

Junie models are Anthropic models served by the JetBrains Grazie backend, which the bundled CLIProxyAPI does not support. Like the existing Cursor provider, `ThinkingProxy` forwards these requests directly over TLS to `ingrazzio-cloud-prod.labs.jb.gg/v1/messages` using a permanent API key stored in `~/.cli-proxy-api/junie.json`. The DroidProxy `junie-` model prefix is stripped before forwarding (e.g. `junie-claude-sonnet-5` → `claude-sonnet-5`).

The JUNP license requires the `X-Accept-EAP-License: true` header.

## Changes

- `Resources/icon-junie.svg` — Junie logo
- `AuthStatus.swift` — `junie` service type
- `ServerManager.swift` — `junie` in `oauthProviderKeys` (provider enable/disable toggle)
- `DroidProxyModelCatalog.swift` — `.junie` model kind and the three model definitions
- `ThinkingProxy.swift` — Junie detection, key loading, model-alias rewrite, and TLS forwarding with streaming
- `SettingsView.swift` — Junie provider row with API-key paste flow

## Testing

Verified end-to-end through the local proxy on `:8317`: all three models return HTTP 200 for both streaming and non-streaming requests, with correct model-alias rewriting.
