### PR TITLE
Add GPT 5.6 Luna codex model with Fast Mode toggle

### DIFF
--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -5,6 +5,7 @@ enum AppPreferences {
     static let gpt55FastModeKey = "gpt55FastMode"
     static let gpt56TerraFastModeKey = "gpt56TerraFastMode"
     static let gpt56SolFastModeKey = "gpt56SolFastMode"
+    static let gpt56LunaFastModeKey = "gpt56LunaFastMode"
     static let allowRemoteKey = "allowRemote"
     static let secretKeyKey = "secretKey"
     static let bindAddressKey = "bindAddress"
@@ -17,6 +18,7 @@ enum AppPreferences {
     static let defaultGpt55FastMode = false
     static let defaultGpt56TerraFastMode = false
     static let defaultGpt56SolFastMode = false
+    static let defaultGpt56LunaFastMode = false
     static let defaultAllowRemote = false
     static let defaultSecretKey = ""
     static let defaultBindAddress = "127.0.0.1"
@@ -39,6 +41,10 @@ enum AppPreferences {
 
     static var gpt56SolFastMode: Bool {
         UserDefaults.standard.bool(forKey: gpt56SolFastModeKey)
+    }
+
+    static var gpt56LunaFastMode: Bool {
+        UserDefaults.standard.bool(forKey: gpt56LunaFastModeKey)
     }
 
     static var allowRemote: Bool {

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -198,6 +198,18 @@ enum DroidProxyModelCatalog {
                 defaultLevelValue: "medium"
             ),
             DroidProxyModelDefinition(
+                baseModel: "gpt-5.6-luna",
+                idSlug: "gpt-5.6-luna",
+                displayName: "GPT 5.6 Luna",
+                maxOutputTokens: 128000,
+                provider: "openai",
+                providerKey: "codex",
+                baseURL: "http://localhost:8317/v1",
+                kind: .codex,
+                levels: gpt56Levels,
+                defaultLevelValue: "medium"
+            ),
+            DroidProxyModelDefinition(
                 baseModel: "gpt-5.6-sol",
                 idSlug: "gpt-5.6-sol",
                 displayName: "GPT 5.6 Sol",

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -333,6 +333,7 @@ struct SettingsView: View {
     @AppStorage(AppPreferences.gpt54FastModeKey) private var gpt54FastMode = AppPreferences.defaultGpt54FastMode
     @AppStorage(AppPreferences.gpt55FastModeKey) private var gpt55FastMode = AppPreferences.defaultGpt55FastMode
     @AppStorage(AppPreferences.gpt56TerraFastModeKey) private var gpt56TerraFastMode = AppPreferences.defaultGpt56TerraFastMode
+    @AppStorage(AppPreferences.gpt56LunaFastModeKey) private var gpt56LunaFastMode = AppPreferences.defaultGpt56LunaFastMode
     @AppStorage(AppPreferences.gpt56SolFastModeKey) private var gpt56SolFastMode = AppPreferences.defaultGpt56SolFastMode
     @AppStorage(AppPreferences.allowRemoteKey) private var allowRemote = AppPreferences.defaultAllowRemote
     @AppStorage(AppPreferences.secretKeyKey) private var secretKey = AppPreferences.defaultSecretKey
@@ -787,6 +788,11 @@ struct SettingsView: View {
                                     "GPT 5.6 Terra",
                                     isOn: $gpt56TerraFastMode,
                                     helpText: "Injects service_tier=priority for GPT 5.6 Terra Responses API requests (Codex fast mode)"
+                                )
+                                codexFastModeToggleRow(
+                                    "GPT 5.6 Luna",
+                                    isOn: $gpt56LunaFastMode,
+                                    helpText: "Injects service_tier=priority for GPT 5.6 Luna Responses API requests (Codex fast mode)"
                                 )
                                 codexFastModeToggleRow(
                                     "GPT 5.6 Sol",

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -858,6 +858,8 @@ class ThinkingProxy {
             guard AppPreferences.gpt55FastMode else { return nil }
         case "gpt-5.6-terra":
             guard AppPreferences.gpt56TerraFastMode else { return nil }
+        case "gpt-5.6-luna":
+            guard AppPreferences.gpt56LunaFastMode else { return nil }
         case "gpt-5.6-sol":
             guard AppPreferences.gpt56SolFastMode else { return nil }
         default:

--- a/src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift
@@ -23,6 +23,20 @@ final class DroidProxyModelCatalogTests: XCTestCase {
         XCTAssertEqual(sonnet["supportedReasoningEfforts"] as? [String], ["low", "medium", "high", "xhigh", "max"])
     }
 
+    func testGpt56LunaUsesNativeModelMetadata() throws {
+        let luna = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:gpt-5.6-luna"))
+
+        XCTAssertEqual(luna["model"] as? String, "gpt-5.6-luna")
+        XCTAssertEqual(luna["provider"] as? String, "openai")
+        XCTAssertEqual(luna["baseUrl"] as? String, "http://localhost:8317/v1")
+        XCTAssertEqual(luna["displayName"] as? String, "DroidProxy: GPT 5.6 Luna")
+        XCTAssertEqual(luna["maxOutputTokens"] as? Int, 128000)
+        XCTAssertEqual(luna["enableThinking"] as? Bool, true)
+        XCTAssertEqual(luna["reasoningEffort"] as? String, "medium")
+        XCTAssertEqual(luna["defaultReasoningEffort"] as? String, "medium")
+        XCTAssertEqual(luna["supportedReasoningEfforts"] as? [String], ["none", "low", "medium", "high", "xhigh", "max"])
+    }
+
     func testGrok45UsesOpenAIProviderAndApiXAIProxy() throws {
         let grok = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:grok-4.5"))
 


### PR DESCRIPTION
## Summary
- register `gpt-5.6-luna` as a Factory custom Codex model with the official GPT-5.6 reasoning levels and a 128k output limit
- add a Luna Fast Mode preference and `service_tier=priority` injection
- cover Luna custom-model metadata with a unit test

API reference: https://developers.openai.com/api/docs/models/gpt-5.6-luna

## Testing
- `swift test` (54 tests passed)
- `swift build -c release --arch arm64`
- built, Developer ID signed, notarized, stapled, and validated `DroidProxy.app`
- local `POST /v1/responses` with `gpt-5.6-luna` returned HTTP 200 and `luna-ok`