### PR TITLE
Add Cursor Grok 4.5 Fast Mode

### DIFF
--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -6,6 +6,7 @@ enum AppPreferences {
     static let gpt56TerraFastModeKey = "gpt56TerraFastMode"
     static let gpt56SolFastModeKey = "gpt56SolFastMode"
     static let gpt56LunaFastModeKey = "gpt56LunaFastMode"
+    static let cursorGrok45FastModeKey = "cursorGrok45FastMode"
     static let allowRemoteKey = "allowRemote"
     static let secretKeyKey = "secretKey"
     static let bindAddressKey = "bindAddress"
@@ -19,6 +20,7 @@ enum AppPreferences {
     static let defaultGpt56TerraFastMode = false
     static let defaultGpt56SolFastMode = false
     static let defaultGpt56LunaFastMode = false
+    static let defaultCursorGrok45FastMode = false
     static let defaultAllowRemote = false
     static let defaultSecretKey = ""
     static let defaultBindAddress = "127.0.0.1"
@@ -45,6 +47,10 @@ enum AppPreferences {
 
     static var gpt56LunaFastMode: Bool {
         UserDefaults.standard.bool(forKey: gpt56LunaFastModeKey)
+    }
+
+    static var cursorGrok45FastMode: Bool {
+        UserDefaults.standard.bool(forKey: cursorGrok45FastModeKey)
     }
 
     static var allowRemote: Bool {

--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -7,6 +7,7 @@ enum AppPreferences {
     static let gpt56SolFastModeKey = "gpt56SolFastMode"
     static let gpt56LunaFastModeKey = "gpt56LunaFastMode"
     /// Grok 4.5 Fast Mode (model-id rewrite to grok-4.5-fast via Cursor API).
+    /// Default is off — same opt-in pattern as Codex GPT Fast Mode keys.
     static let grok45FastModeKey = "grok45FastMode"
     static let allowRemoteKey = "allowRemote"
     static let secretKeyKey = "secretKey"

--- a/src/Sources/AppPreferences.swift
+++ b/src/Sources/AppPreferences.swift
@@ -6,7 +6,8 @@ enum AppPreferences {
     static let gpt56TerraFastModeKey = "gpt56TerraFastMode"
     static let gpt56SolFastModeKey = "gpt56SolFastMode"
     static let gpt56LunaFastModeKey = "gpt56LunaFastMode"
-    static let cursorGrok45FastModeKey = "cursorGrok45FastMode"
+    /// Grok 4.5 Fast Mode (model-id rewrite to grok-4.5-fast via Cursor API).
+    static let grok45FastModeKey = "grok45FastMode"
     static let allowRemoteKey = "allowRemote"
     static let secretKeyKey = "secretKey"
     static let bindAddressKey = "bindAddress"
@@ -20,7 +21,7 @@ enum AppPreferences {
     static let defaultGpt56TerraFastMode = false
     static let defaultGpt56SolFastMode = false
     static let defaultGpt56LunaFastMode = false
-    static let defaultCursorGrok45FastMode = false
+    static let defaultGrok45FastMode = false
     static let defaultAllowRemote = false
     static let defaultSecretKey = ""
     static let defaultBindAddress = "127.0.0.1"
@@ -49,8 +50,8 @@ enum AppPreferences {
         UserDefaults.standard.bool(forKey: gpt56LunaFastModeKey)
     }
 
-    static var cursorGrok45FastMode: Bool {
-        UserDefaults.standard.bool(forKey: cursorGrok45FastModeKey)
+    static var grok45FastMode: Bool {
+        UserDefaults.standard.bool(forKey: grok45FastModeKey)
     }
 
     static var allowRemote: Bool {

--- a/src/Sources/CursorModelRewriter.swift
+++ b/src/Sources/CursorModelRewriter.swift
@@ -1,29 +1,35 @@
 import Foundation
 
-/// Resolves DroidProxy Cursor catalog model ids to upstream Cursor API model ids.
+/// Resolves Cursor catalog ids and Grok Fast Mode rewrites for the hosted Cursor API.
 ///
-/// Catalog entries use a `cursor-` prefix so `ThinkingProxy.isCursorModel` routes to
-/// `api-for-cursor.standardagents.ai` (not api.x.ai Grok OAuth). Upstream ids match
-/// standardagents/composer-api (`grok-4.5`, `grok-4.5-fast`, `composer-2.5`, …).
-///
-/// Fast Mode rewrites `grok-4.5` → `grok-4.5-fast` (model-id swap, not Codex
-/// `service_tier=priority`). Explicit `cursor-grok-4.5-fast` always maps to the fast id.
+/// - Catalog entries use a `cursor-` prefix so ThinkingProxy routes to
+///   `api-for-cursor.standardagents.ai` (not api.x.ai Grok OAuth).
+/// - Upstream ids match standardagents/composer-api (`grok-4.5`, `grok-4.5-fast`, …).
+/// - Fast Mode rewrites `grok-4.5` → `grok-4.5-fast` (model-id swap). api.x.ai does
+///   **not** expose `grok-4.5-fast` (HTTP 400); Fast Mode must use the Cursor API.
 enum CursorModelRewriter {
     static let host = "api-for-cursor.standardagents.ai"
+    static let grok45Model = "grok-4.5"
+    static let grok45FastModel = "grok-4.5-fast"
 
     /// Catalog id → upstream Cursor API model id (before Fast Mode).
     static let aliases: [String: String] = [
         "cursor-composer-2.5": "composer-2.5",
-        "cursor-grok-4.5": "grok-4.5",
-        "cursor-grok-4.5-fast": "grok-4.5-fast"
+        "cursor-grok-4.5": grok45Model,
+        "cursor-grok-4.5-fast": grok45FastModel
     ]
 
     /// Returns the upstream model id to send to the Cursor API.
     static func resolveUpstreamModel(_ catalogModel: String, grok45FastMode: Bool) -> String {
         let aliased = aliases[catalogModel] ?? catalogModel
-        if grok45FastMode && aliased == "grok-4.5" {
-            return "grok-4.5-fast"
+        if grok45FastMode && aliased == grok45Model {
+            return grok45FastModel
         }
         return aliased
+    }
+
+    /// Whether Grok OAuth Fast Mode should divert `grok-4.5` to the Cursor API.
+    static func shouldDivertGrokOAuthToCursorFast(model: String, grok45FastMode: Bool) -> Bool {
+        grok45FastMode && model == grok45Model
     }
 }

--- a/src/Sources/CursorModelRewriter.swift
+++ b/src/Sources/CursorModelRewriter.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Resolves DroidProxy Cursor catalog model ids to upstream Cursor API model ids.
+///
+/// Catalog entries use a `cursor-` prefix so `ThinkingProxy.isCursorModel` routes to
+/// `api-for-cursor.standardagents.ai` (not api.x.ai Grok OAuth). Upstream ids match
+/// standardagents/composer-api (`grok-4.5`, `grok-4.5-fast`, `composer-2.5`, …).
+///
+/// Fast Mode rewrites `grok-4.5` → `grok-4.5-fast` (model-id swap, not Codex
+/// `service_tier=priority`). Explicit `cursor-grok-4.5-fast` always maps to the fast id.
+enum CursorModelRewriter {
+    static let host = "api-for-cursor.standardagents.ai"
+
+    /// Catalog id → upstream Cursor API model id (before Fast Mode).
+    static let aliases: [String: String] = [
+        "cursor-composer-2.5": "composer-2.5",
+        "cursor-grok-4.5": "grok-4.5",
+        "cursor-grok-4.5-fast": "grok-4.5-fast"
+    ]
+
+    /// Returns the upstream model id to send to the Cursor API.
+    static func resolveUpstreamModel(_ catalogModel: String, grok45FastMode: Bool) -> String {
+        let aliased = aliases[catalogModel] ?? catalogModel
+        if grok45FastMode && aliased == "grok-4.5" {
+            return "grok-4.5-fast"
+        }
+        return aliased
+    }
+}

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -460,12 +460,10 @@ enum DroidProxyModelCatalog {
     /// driven by top-level `compactionTokenLimit` / `compactionTokenLimitPerModel`
     /// (custom BYOK ids resolve to infinite maxInputTokens otherwise). Thresholds sit
     /// under each provider's effective window so compaction fires before a hard 400.
-    static var factoryCompactionTokenLimitPerModel: [String: Int] {
-        [
-            // api.x.ai: grok-4.5=500k, grok-4.3=1M, grok-build-0.1=256k
-            "custom:droidproxy:grok-4.5": 400_000,
-            "custom:droidproxy:grok-4.3": 800_000,
-            "custom:droidproxy:grok-build-0.1": 200_000
-        ]
-    }
+    static let factoryCompactionTokenLimitPerModel: [String: Int] = [
+        // api.x.ai: grok-4.5=500k, grok-4.3=1M, grok-build-0.1=256k
+        "custom:droidproxy:grok-4.5": 400_000,
+        "custom:droidproxy:grok-4.3": 800_000,
+        "custom:droidproxy:grok-build-0.1": 200_000
+    ]
 }

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -20,6 +20,9 @@ struct DroidProxyModelDefinition: Equatable {
     let idSlug: String
     let displayName: String
     let maxOutputTokens: Int
+    /// Optional Factory `maxContextLimit` (accepted by customModels schema).
+    /// Compaction still primarily uses root `compactionTokenLimitPerModel`.
+    let maxContextLimit: Int?
     let provider: String
     let providerKey: String
     let baseURL: String
@@ -31,6 +34,7 @@ struct DroidProxyModelDefinition: Equatable {
          idSlug: String,
          displayName: String,
          maxOutputTokens: Int,
+         maxContextLimit: Int? = nil,
          provider: String,
          providerKey: String,
          baseURL: String,
@@ -41,6 +45,7 @@ struct DroidProxyModelDefinition: Equatable {
         self.idSlug = idSlug
         self.displayName = displayName
         self.maxOutputTokens = maxOutputTokens
+        self.maxContextLimit = maxContextLimit
         self.provider = provider
         self.providerKey = providerKey
         self.baseURL = baseURL
@@ -77,6 +82,9 @@ struct DroidProxyModelDefinition: Equatable {
             "noImageSupport": false,
             "provider": provider
         ]
+        if let maxContextLimit {
+            entry["maxContextLimit"] = maxContextLimit
+        }
         guard !levels.isEmpty else { return entry }
         entry["enableThinking"] = true
         entry["supportedReasoningEfforts"] = levels.map(\.value)
@@ -337,11 +345,13 @@ enum DroidProxyModelCatalog {
 
             // Grok OAuth (SuperGrok / X Premium+) via api.x.ai.
             // provider="openai" + /v1 → Responses API; ThinkingProxy attaches the bearer.
+            // Context windows from docs.x.ai (Jul 2026): 4.5=500k, 4.3=1M, Build=256k.
             DroidProxyModelDefinition(
                 baseModel: "grok-4.5",
                 idSlug: "grok-4.5",
                 displayName: "Grok 4.5",
                 maxOutputTokens: 128000,
+                maxContextLimit: 500_000,
                 provider: "openai",
                 providerKey: "grok",
                 baseURL: "http://localhost:8317/v1",
@@ -354,6 +364,7 @@ enum DroidProxyModelCatalog {
                 idSlug: "grok-4.3",
                 displayName: "Grok 4.3",
                 maxOutputTokens: 128000,
+                maxContextLimit: 1_000_000,
                 provider: "openai",
                 providerKey: "grok",
                 baseURL: "http://localhost:8317/v1",
@@ -366,6 +377,7 @@ enum DroidProxyModelCatalog {
                 idSlug: "grok-build-0.1",
                 displayName: "Grok Build",
                 maxOutputTokens: 128000,
+                maxContextLimit: 256_000,
                 provider: "openai",
                 providerKey: "grok",
                 baseURL: "http://localhost:8317/v1",
@@ -381,6 +393,30 @@ enum DroidProxyModelCatalog {
                     baseModel: "cursor-composer-2.5",
                     idSlug: "cursor-composer-2.5",
                     displayName: "Cursor Composer 2.5",
+                    maxOutputTokens: 128000,
+                    provider: "generic-chat-completion-api",
+                    providerKey: "cursor",
+                    baseURL: "http://localhost:8317/v1",
+                    kind: .cursor,
+                    levels: [high],
+                    defaultLevelValue: "high"
+                ),
+                DroidProxyModelDefinition(
+                    baseModel: "cursor-grok-4.5",
+                    idSlug: "cursor-grok-4.5",
+                    displayName: "Cursor Grok 4.5",
+                    maxOutputTokens: 128000,
+                    provider: "generic-chat-completion-api",
+                    providerKey: "cursor",
+                    baseURL: "http://localhost:8317/v1",
+                    kind: .cursor,
+                    levels: [high],
+                    defaultLevelValue: "high"
+                ),
+                DroidProxyModelDefinition(
+                    baseModel: "cursor-grok-4.5-fast",
+                    idSlug: "cursor-grok-4.5-fast",
+                    displayName: "Cursor Grok 4.5 Fast",
                     maxOutputTokens: 128000,
                     provider: "generic-chat-completion-api",
                     providerKey: "cursor",
@@ -416,5 +452,20 @@ enum DroidProxyModelCatalog {
 
     static var allSettingsIDs: Set<String> {
         Set(definitions.map(\.simpleID))
+    }
+
+    /// Factory root-level `compactionTokenLimitPerModel` entries for BYOK models.
+    ///
+    /// Custom models also accept `maxContextLimit`, but Droid's auto-compaction is
+    /// driven by top-level `compactionTokenLimit` / `compactionTokenLimitPerModel`
+    /// (custom BYOK ids resolve to infinite maxInputTokens otherwise). Thresholds sit
+    /// under each provider's effective window so compaction fires before a hard 400.
+    static var factoryCompactionTokenLimitPerModel: [String: Int] {
+        [
+            // api.x.ai: grok-4.5=500k, grok-4.3=1M, grok-build-0.1=256k
+            "custom:droidproxy:grok-4.5": 400_000,
+            "custom:droidproxy:grok-4.3": 800_000,
+            "custom:droidproxy:grok-build-0.1": 200_000
+        ]
     }
 }

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -335,6 +335,7 @@ struct SettingsView: View {
     @AppStorage(AppPreferences.gpt56TerraFastModeKey) private var gpt56TerraFastMode = AppPreferences.defaultGpt56TerraFastMode
     @AppStorage(AppPreferences.gpt56LunaFastModeKey) private var gpt56LunaFastMode = AppPreferences.defaultGpt56LunaFastMode
     @AppStorage(AppPreferences.gpt56SolFastModeKey) private var gpt56SolFastMode = AppPreferences.defaultGpt56SolFastMode
+    @AppStorage(AppPreferences.cursorGrok45FastModeKey) private var cursorGrok45FastMode = AppPreferences.defaultCursorGrok45FastMode
     @AppStorage(AppPreferences.allowRemoteKey) private var allowRemote = AppPreferences.defaultAllowRemote
     @AppStorage(AppPreferences.secretKeyKey) private var secretKey = AppPreferences.defaultSecretKey
     @AppStorage(AppPreferences.bindAddressKey) private var bindAddress = AppPreferences.defaultBindAddress
@@ -356,6 +357,7 @@ struct SettingsView: View {
     @State private var factoryModelsInstalled = false
     @State private var remoteManagementExpanded = false
     @State private var codexFastModeExpanded = true
+    @State private var cursorFastModeExpanded = true
     private let claudeEffortSelectionColor = Color(red: 0xD9/255, green: 0x77/255, blue: 0x57/255)
     private let codexEffortSelectionColor = Color(red: 0x74/255, green: 0xAA/255, blue: 0x9C/255)
     private let antigravityEffortSelectionColor = Color(red: 0x42/255, green: 0x85/255, blue: 0xF4/255)
@@ -836,8 +838,36 @@ struct SettingsView: View {
                             .cursor,
                             iconName: "icon-cursor.png",
                             toggleTint: cursorEffortSelectionColor,
-                            helpText: "Enter your Cursor API Key (from https://cursor-api.standardagents.ai/) to proxy requests directly to Cursor."
+                            helpText: "Enter your Cursor API Key (from https://api-for-cursor.standardagents.ai/) to proxy requests directly to Cursor."
                         )
+
+                        if serverManager.isProviderEnabled(.cursor) {
+                            VStack(alignment: .leading, spacing: 6) {
+                                HStack(spacing: 4) {
+                                    Text("Fast Mode")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                    Image(systemName: cursorFastModeExpanded ? "chevron.down" : "chevron.right")
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                    Spacer()
+                                }
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    withAnimation(.easeInOut(duration: 0.2)) {
+                                        cursorFastModeExpanded.toggle()
+                                    }
+                                }
+                                if cursorFastModeExpanded {
+                                    codexFastModeToggleRow(
+                                        "Grok 4.5",
+                                        isOn: $cursorGrok45FastMode,
+                                        helpText: "Rewrites Cursor Grok 4.5 requests to grok-4.5-fast (model-id Fast Mode, not Codex service_tier)"
+                                    )
+                                }
+                            }
+                            .padding(.leading, 28)
+                        }
                     }
                 }
                 .listRowBackground(glassRowBackground)
@@ -1337,6 +1367,7 @@ struct SettingsView: View {
         }
 
         settings["customModels"] = models
+        mergeFactoryCompactionTokenLimits(&settings)
 
         do {
             backupFactorySettingsIfPresent(url)
@@ -1348,13 +1379,27 @@ struct SettingsView: View {
             }
             try data.write(to: url, options: .atomic)
             factoryModelsInstalled = true
-            authResultMessage = "DroidProxy models added to Factory settings.\n\nA timestamped backup was saved next to settings.json before writing. Reasoning effort is controlled from Droid CLI per session when the selected model exposes multiple levels. Restart Factory or open a new session to see them in the model picker."
+            authResultMessage = "DroidProxy models merged into Factory settings.\n\nYour other custom models were kept. Only previous DroidProxy entries were replaced. Grok compaction limits were written to compactionTokenLimitPerModel. A timestamped backup was saved next to settings.json.\n\nIn Droid CLI use /model and search for “DroidProxy:”. Restart Factory or open a new session if the picker looks stale. Reasoning effort is controlled from Droid per session when the model exposes multiple levels."
             showingAuthResult = true
             NSLog("[SettingsView] Factory custom models applied to %@", url.path)
         } catch {
             authResultMessage = "Failed to update Factory settings: \(error.localizedDescription)"
             showingAuthResult = true
             NSLog("[SettingsView] Failed to apply Factory custom models: %@", error.localizedDescription)
+        }
+    }
+
+    /// Merge BYOK compaction thresholds into Factory's root-level
+    /// `compactionTokenLimitPerModel`. Custom models accept `maxContextLimit`, but
+    /// Droid auto-compaction is driven by this documented root setting.
+    private func mergeFactoryCompactionTokenLimits(_ settings: inout [String: Any]) {
+        var perModel = (settings["compactionTokenLimitPerModel"] as? [String: Any]) ?? [:]
+        for (modelID, limit) in DroidProxyModelCatalog.factoryCompactionTokenLimitPerModel {
+            perModel[modelID] = limit
+        }
+        settings["compactionTokenLimitPerModel"] = perModel
+        if settings["compactionModelMode"] == nil {
+            settings["compactionModelMode"] = "same"
         }
     }
 

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -1021,7 +1021,7 @@ struct SettingsView: View {
     @ViewBuilder
     private func codexFastModeToggleRow(_ title: String, isOn: Binding<Bool>, helpText: String) -> some View {
         HStack {
-            Text("\(title) fast mode")
+            Text(title)
                 .font(.caption)
                 .foregroundColor(.secondary)
             Spacer()

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -1398,7 +1398,8 @@ struct SettingsView: View {
             perModel[modelID] = limit
         }
         settings["compactionTokenLimitPerModel"] = perModel
-        if settings["compactionModelMode"] == nil {
+        // JSON null becomes NSNull, so `== nil` is not enough.
+        if !(settings["compactionModelMode"] is String) {
             settings["compactionModelMode"] = "same"
         }
     }

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -335,7 +335,7 @@ struct SettingsView: View {
     @AppStorage(AppPreferences.gpt56TerraFastModeKey) private var gpt56TerraFastMode = AppPreferences.defaultGpt56TerraFastMode
     @AppStorage(AppPreferences.gpt56LunaFastModeKey) private var gpt56LunaFastMode = AppPreferences.defaultGpt56LunaFastMode
     @AppStorage(AppPreferences.gpt56SolFastModeKey) private var gpt56SolFastMode = AppPreferences.defaultGpt56SolFastMode
-    @AppStorage(AppPreferences.cursorGrok45FastModeKey) private var cursorGrok45FastMode = AppPreferences.defaultCursorGrok45FastMode
+    @AppStorage(AppPreferences.grok45FastModeKey) private var grok45FastMode = AppPreferences.defaultGrok45FastMode
     @AppStorage(AppPreferences.allowRemoteKey) private var allowRemote = AppPreferences.defaultAllowRemote
     @AppStorage(AppPreferences.secretKeyKey) private var secretKey = AppPreferences.defaultSecretKey
     @AppStorage(AppPreferences.bindAddressKey) private var bindAddress = AppPreferences.defaultBindAddress
@@ -357,7 +357,7 @@ struct SettingsView: View {
     @State private var factoryModelsInstalled = false
     @State private var remoteManagementExpanded = false
     @State private var codexFastModeExpanded = true
-    @State private var cursorFastModeExpanded = true
+    @State private var grokFastModeExpanded = true
     private let claudeEffortSelectionColor = Color(red: 0xD9/255, green: 0x77/255, blue: 0x57/255)
     private let codexEffortSelectionColor = Color(red: 0x74/255, green: 0xAA/255, blue: 0x9C/255)
     private let antigravityEffortSelectionColor = Color(red: 0x42/255, green: 0x85/255, blue: 0xF4/255)
@@ -833,41 +833,41 @@ struct SettingsView: View {
                         helpText: "Log in with SuperGrok / X Premium+ to use Grok 4.5 via api.x.ai (supported tiers; no xAI API key)."
                     )
 
+                    if serverManager.isProviderEnabled(.grok) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 4) {
+                                Text("Fast Mode")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                Image(systemName: grokFastModeExpanded ? "chevron.down" : "chevron.right")
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                                Spacer()
+                            }
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    grokFastModeExpanded.toggle()
+                                }
+                            }
+                            if grokFastModeExpanded {
+                                codexFastModeToggleRow(
+                                    "Grok 4.5",
+                                    isOn: $grok45FastMode,
+                                    helpText: "Rewrites grok-4.5 → grok-4.5-fast via the Cursor API (api.x.ai has no grok-4.5-fast). Requires a Cursor API key under Beta → Cursor."
+                                )
+                            }
+                        }
+                        .padding(.leading, 28)
+                    }
+
                     if betaFlag {
                         providerServiceRow(
                             .cursor,
                             iconName: "icon-cursor.png",
                             toggleTint: cursorEffortSelectionColor,
-                            helpText: "Enter your Cursor API Key (from https://api-for-cursor.standardagents.ai/) to proxy requests directly to Cursor."
+                            helpText: "Enter your Cursor API Key (from https://api-for-cursor.standardagents.ai/) to proxy requests directly to Cursor. Also powers Grok 4.5 Fast Mode."
                         )
-
-                        if serverManager.isProviderEnabled(.cursor) {
-                            VStack(alignment: .leading, spacing: 6) {
-                                HStack(spacing: 4) {
-                                    Text("Fast Mode")
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                    Image(systemName: cursorFastModeExpanded ? "chevron.down" : "chevron.right")
-                                        .font(.caption2)
-                                        .foregroundColor(.secondary)
-                                    Spacer()
-                                }
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    withAnimation(.easeInOut(duration: 0.2)) {
-                                        cursorFastModeExpanded.toggle()
-                                    }
-                                }
-                                if cursorFastModeExpanded {
-                                    codexFastModeToggleRow(
-                                        "Grok 4.5",
-                                        isOn: $cursorGrok45FastMode,
-                                        helpText: "Rewrites Cursor Grok 4.5 requests to grok-4.5-fast (model-id Fast Mode, not Codex service_tier)"
-                                    )
-                                }
-                            }
-                            .padding(.leading, 28)
-                        }
                     }
                 }
                 .listRowBackground(glassRowBackground)

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -464,10 +464,6 @@ class ThinkingProxy {
         "ag-c46o-thinking": "claude-opus-4-6-thinking"
     ]
 
-    private static let cursorModelAliases: [String: String] = [
-        "cursor-composer-2.5": "composer-2.5"
-    ]
-
     private func rewriteAntigravityModelAlias(jsonString: String, fields: RequestJSONFields?) -> String? {
         guard let model = fields?.model,
               let modelLocation = fields?.modelLocation,
@@ -483,14 +479,19 @@ class ThinkingProxy {
 
     private func rewriteCursorModelAlias(jsonString: String, fields: RequestJSONFields?) -> String? {
         guard let model = fields?.model,
-              let modelLocation = fields?.modelLocation,
-              let backendModel = Self.cursorModelAliases[model] else {
+              let modelLocation = fields?.modelLocation else {
             return nil
         }
 
+        let backendModel = CursorModelRewriter.resolveUpstreamModel(
+            model,
+            grok45FastMode: AppPreferences.cursorGrok45FastMode
+        )
+        guard backendModel != model else { return nil }
+
         var result = jsonString
         result.replaceSubrange(modelLocation.valueRange, with: "\"\(backendModel)\"")
-        ThinkingProxy.fileLog("REWRITE MODEL: \(model) -> \(backendModel) (Cursor alias)")
+        ThinkingProxy.fileLog("REWRITE MODEL: \(model) -> \(backendModel) (Cursor)")
         return result
     }
 
@@ -1074,7 +1075,8 @@ class ThinkingProxy {
         let tlsOptions = NWProtocolTLS.Options()
         let parameters = NWParameters(tls: tlsOptions, tcp: NWProtocolTCP.Options())
         
-        let endpoint = NWEndpoint.hostPort(host: "cursor-api.standardagents.ai", port: 443)
+        let cursorHost = CursorModelRewriter.host
+        let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(cursorHost), port: 443)
         let targetConnection = NWConnection(to: endpoint, using: parameters)
         
         targetConnection.stateUpdateHandler = { [weak self] state in
@@ -1089,7 +1091,7 @@ class ThinkingProxy {
                     }
                 }
                 
-                forwardedRequest += "Host: cursor-api.standardagents.ai\r\n"
+                forwardedRequest += "Host: \(cursorHost)\r\n"
                 forwardedRequest += "Authorization: Bearer \(apiKey)\r\n"
                 forwardedRequest += "Connection: close\r\n"
                 forwardedRequest += "Content-Length: \(body.utf8.count)\r\n\r\n"
@@ -1098,7 +1100,7 @@ class ThinkingProxy {
                 if let requestData = forwardedRequest.data(using: .utf8) {
                     targetConnection.send(content: requestData, completion: .contentProcessed({ error in
                         if let error = error {
-                            NSLog("[ThinkingProxy] Send error to cursor-api.standardagents.ai: \(error)")
+                            NSLog("[ThinkingProxy] Send error to \(cursorHost): \(error)")
                             targetConnection.cancel()
                             originalConnection.cancel()
                         } else {
@@ -1108,8 +1110,8 @@ class ThinkingProxy {
                 }
                 
             case .failed(let error):
-                NSLog("[ThinkingProxy] Connection to cursor-api.standardagents.ai failed: \(error)")
-                self.sendError(to: originalConnection, statusCode: 502, message: "Bad Gateway - Could not connect to cursor-api.standardagents.ai")
+                NSLog("[ThinkingProxy] Connection to \(cursorHost) failed: \(error)")
+                self.sendError(to: originalConnection, statusCode: 502, message: "Bad Gateway - Could not connect to \(cursorHost)")
                 targetConnection.cancel()
                 
             default:

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -1134,7 +1134,7 @@ class ThinkingProxy {
                 if let requestData = forwardedRequest.data(using: .utf8) {
                     targetConnection.send(content: requestData, completion: .contentProcessed({ error in
                         if let error = error {
-                            NSLog("[ThinkingProxy] Send error to \(cursorHost): \(error)")
+                            NSLog("[ThinkingProxy] Send error to %@: %@", cursorHost, "\(error)")
                             targetConnection.cancel()
                             originalConnection.cancel()
                         } else {
@@ -1144,7 +1144,7 @@ class ThinkingProxy {
                 }
                 
             case .failed(let error):
-                NSLog("[ThinkingProxy] Connection to \(cursorHost) failed: \(error)")
+                NSLog("[ThinkingProxy] Connection to %@ failed: %@", cursorHost, "\(error)")
                 self.sendError(to: originalConnection, statusCode: 502, message: "Bad Gateway - Could not connect to \(cursorHost)")
                 targetConnection.cancel()
                 

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -356,6 +356,40 @@ class ThinkingProxy {
                     sendError(to: connection, statusCode: 400, message: "Grok provider is disabled in DroidProxy settings.")
                     return
                 }
+                // Grok 4.5 Fast Mode: api.x.ai has no grok-4.5-fast (400). Divert to
+                // Cursor's hosted API when Fast Mode is on and a Cursor key exists.
+                if let model = requestFields?.model,
+                   CursorModelRewriter.shouldDivertGrokOAuthToCursorFast(
+                    model: model,
+                    grok45FastMode: AppPreferences.grok45FastMode
+                   ) {
+                    guard loadCursorApiKey() != nil else {
+                        sendError(
+                            to: connection,
+                            statusCode: 401,
+                            message: "Grok 4.5 Fast Mode requires a Cursor API key. Enable Beta → Cursor and add your key (api.x.ai does not offer grok-4.5-fast)."
+                        )
+                        return
+                    }
+                    if let modelLocation = requestFields?.modelLocation {
+                        modifiedBody.replaceSubrange(
+                            modelLocation.valueRange,
+                            with: "\"\(CursorModelRewriter.grok45FastModel)\""
+                        )
+                        ThinkingProxy.fileLog(
+                            "REWRITE MODEL: \(model) -> \(CursorModelRewriter.grok45FastModel) (Grok Fast Mode → Cursor API)"
+                        )
+                    }
+                    forwardToCursor(
+                        method: method,
+                        path: rewrittenPath,
+                        version: httpVersion,
+                        headers: headers,
+                        body: modifiedBody,
+                        originalConnection: connection
+                    )
+                    return
+                }
                 let grokBody = GrokRequestSanitizer.sanitize(modifiedBody)
                 if grokBody != modifiedBody {
                     ThinkingProxy.fileLog("SANITIZED GROK: remapped custom tools/calls and dropped unsupported fields before api.x.ai")
@@ -485,7 +519,7 @@ class ThinkingProxy {
 
         let backendModel = CursorModelRewriter.resolveUpstreamModel(
             model,
-            grok45FastMode: AppPreferences.cursorGrok45FastMode
+            grok45FastMode: AppPreferences.grok45FastMode
         )
         guard backendModel != model else { return nil }
 

--- a/src/Tests/CLIProxyMenuBarTests/AppPreferencesFastModeDefaultsTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/AppPreferencesFastModeDefaultsTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import CLIProxyMenuBar
+
+final class AppPreferencesFastModeDefaultsTests: XCTestCase {
+    /// Fast Mode is opt-in for every provider (Codex GPT + Grok). Absent keys
+    /// must read as false so the Settings checkboxes start unchecked.
+    func testAllFastModeDefaultsAreOff() {
+        XCTAssertFalse(AppPreferences.defaultGpt54FastMode)
+        XCTAssertFalse(AppPreferences.defaultGpt55FastMode)
+        XCTAssertFalse(AppPreferences.defaultGpt56TerraFastMode)
+        XCTAssertFalse(AppPreferences.defaultGpt56LunaFastMode)
+        XCTAssertFalse(AppPreferences.defaultGpt56SolFastMode)
+        XCTAssertFalse(AppPreferences.defaultGrok45FastMode)
+    }
+
+    func testUnsetFastModeKeysReadAsFalse() {
+        let defaults = UserDefaults.standard
+        let keys = [
+            AppPreferences.gpt54FastModeKey,
+            AppPreferences.gpt55FastModeKey,
+            AppPreferences.gpt56TerraFastModeKey,
+            AppPreferences.gpt56LunaFastModeKey,
+            AppPreferences.gpt56SolFastModeKey,
+            AppPreferences.grok45FastModeKey
+        ]
+        for key in keys {
+            defaults.removeObject(forKey: key)
+        }
+        XCTAssertFalse(AppPreferences.gpt54FastMode)
+        XCTAssertFalse(AppPreferences.gpt55FastMode)
+        XCTAssertFalse(AppPreferences.gpt56TerraFastMode)
+        XCTAssertFalse(AppPreferences.gpt56LunaFastMode)
+        XCTAssertFalse(AppPreferences.gpt56SolFastMode)
+        XCTAssertFalse(AppPreferences.grok45FastMode)
+    }
+}

--- a/src/Tests/CLIProxyMenuBarTests/CursorModelRewriterTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/CursorModelRewriterTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import CLIProxyMenuBar
+
+final class CursorModelRewriterTests: XCTestCase {
+    func testAliasesMapCatalogIdsToUpstreamCursorModels() {
+        XCTAssertEqual(
+            CursorModelRewriter.resolveUpstreamModel("cursor-composer-2.5", grok45FastMode: false),
+            "composer-2.5"
+        )
+        XCTAssertEqual(
+            CursorModelRewriter.resolveUpstreamModel("cursor-grok-4.5", grok45FastMode: false),
+            "grok-4.5"
+        )
+        XCTAssertEqual(
+            CursorModelRewriter.resolveUpstreamModel("cursor-grok-4.5-fast", grok45FastMode: false),
+            "grok-4.5-fast"
+        )
+    }
+
+    func testFastModeRewritesGrok45ToFast() {
+        XCTAssertEqual(
+            CursorModelRewriter.resolveUpstreamModel("cursor-grok-4.5", grok45FastMode: true),
+            "grok-4.5-fast"
+        )
+        // Explicit Fast catalog entry stays fast regardless of the checkbox.
+        XCTAssertEqual(
+            CursorModelRewriter.resolveUpstreamModel("cursor-grok-4.5-fast", grok45FastMode: true),
+            "grok-4.5-fast"
+        )
+        XCTAssertEqual(
+            CursorModelRewriter.resolveUpstreamModel("cursor-composer-2.5", grok45FastMode: true),
+            "composer-2.5"
+        )
+    }
+
+    func testUnknownCursorIdsPassThrough() {
+        XCTAssertEqual(
+            CursorModelRewriter.resolveUpstreamModel("cursor-small", grok45FastMode: true),
+            "cursor-small"
+        )
+    }
+
+    func testHostPointsAtCurrentStandardAgentsAPI() {
+        XCTAssertEqual(CursorModelRewriter.host, "api-for-cursor.standardagents.ai")
+    }
+}

--- a/src/Tests/CLIProxyMenuBarTests/CursorModelRewriterTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/CursorModelRewriterTests.swift
@@ -22,6 +22,10 @@ final class CursorModelRewriterTests: XCTestCase {
             CursorModelRewriter.resolveUpstreamModel("cursor-grok-4.5", grok45FastMode: true),
             "grok-4.5-fast"
         )
+        XCTAssertEqual(
+            CursorModelRewriter.resolveUpstreamModel("grok-4.5", grok45FastMode: true),
+            "grok-4.5-fast"
+        )
         // Explicit Fast catalog entry stays fast regardless of the checkbox.
         XCTAssertEqual(
             CursorModelRewriter.resolveUpstreamModel("cursor-grok-4.5-fast", grok45FastMode: true),
@@ -30,6 +34,18 @@ final class CursorModelRewriterTests: XCTestCase {
         XCTAssertEqual(
             CursorModelRewriter.resolveUpstreamModel("cursor-composer-2.5", grok45FastMode: true),
             "composer-2.5"
+        )
+    }
+
+    func testGrokOAuthFastDivertPredicate() {
+        XCTAssertTrue(
+            CursorModelRewriter.shouldDivertGrokOAuthToCursorFast(model: "grok-4.5", grok45FastMode: true)
+        )
+        XCTAssertFalse(
+            CursorModelRewriter.shouldDivertGrokOAuthToCursorFast(model: "grok-4.5", grok45FastMode: false)
+        )
+        XCTAssertFalse(
+            CursorModelRewriter.shouldDivertGrokOAuthToCursorFast(model: "grok-4.3", grok45FastMode: true)
         )
     }
 

--- a/src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift
@@ -46,6 +46,7 @@ final class DroidProxyModelCatalogTests: XCTestCase {
         XCTAssertEqual(grok["displayName"] as? String, "DroidProxy: Grok 4.5")
         XCTAssertEqual(grok["supportedReasoningEfforts"] as? [String], ["low", "medium", "high", "xhigh"])
         XCTAssertEqual(grok["defaultReasoningEffort"] as? String, "high")
+        XCTAssertEqual(grok["maxContextLimit"] as? Int, 500_000)
     }
 
     func testGrokProviderModelsAreRegistered() {
@@ -53,6 +54,38 @@ final class DroidProxyModelCatalogTests: XCTestCase {
         XCTAssertTrue(ids.contains("custom:droidproxy:grok-4.5"))
         XCTAssertTrue(ids.contains("custom:droidproxy:grok-4.3"))
         XCTAssertTrue(ids.contains("custom:droidproxy:grok-build-0.1"))
+    }
+
+    func testGrokContextLimitsMatchXAIDocs() throws {
+        let grok45 = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:grok-4.5"))
+        let grok43 = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:grok-4.3"))
+        let build = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:grok-build-0.1"))
+
+        XCTAssertEqual(grok45["maxContextLimit"] as? Int, 500_000)
+        XCTAssertEqual(grok43["maxContextLimit"] as? Int, 1_000_000)
+        XCTAssertEqual(build["maxContextLimit"] as? Int, 256_000)
+    }
+
+    func testFactoryCompactionLimitsSitUnderGrokWindows() {
+        let limits = DroidProxyModelCatalog.factoryCompactionTokenLimitPerModel
+        XCTAssertEqual(limits["custom:droidproxy:grok-4.5"], 400_000)
+        XCTAssertEqual(limits["custom:droidproxy:grok-4.3"], 800_000)
+        XCTAssertEqual(limits["custom:droidproxy:grok-build-0.1"], 200_000)
+    }
+
+    func testCursorGrokModelsAppearWhenBetaEnabled() throws {
+        let previous = BETA_FLAG
+        BETA_FLAG = true
+        defer { BETA_FLAG = previous }
+
+        let standard = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:cursor-grok-4.5"))
+        let fast = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:cursor-grok-4.5-fast"))
+
+        XCTAssertEqual(standard["model"] as? String, "cursor-grok-4.5")
+        XCTAssertEqual(standard["provider"] as? String, "generic-chat-completion-api")
+        XCTAssertEqual(standard["displayName"] as? String, "DroidProxy: Cursor Grok 4.5")
+        XCTAssertEqual(fast["model"] as? String, "cursor-grok-4.5-fast")
+        XCTAssertEqual(fast["displayName"] as? String, "DroidProxy: Cursor Grok 4.5 Fast")
     }
 
     private func settingsEntry(id: String) -> [String: Any]? {


### PR DESCRIPTION
## Summary
- Beta catalog entries `cursor-grok-4.5` / `cursor-grok-4.5-fast` with ThinkingProxy aliases to hosted Cursor API ids (`grok-4.5` / `grok-4.5-fast`).
- **Grok → Fast Mode → Grok 4.5**: model-id rewrite `grok-4.5` → `grok-4.5-fast`. api.x.ai does **not** offer `grok-4.5-fast` (400); Fast Mode diverts to the Cursor API and requires a Cursor API key under Beta → Cursor (clear 401 if missing).
- Point Cursor forwarding at `api-for-cursor.standardagents.ai` — `cursor-api.standardagents.ai` returns HTTP 308 and NWConnection cannot follow redirects.
- Set api.x.ai Grok `maxContextLimit` / Factory compaction thresholds from current xAI docs (4.5=500k, 4.3=1M, Build=256k).

## Test plan
- [x] `cd src && swift test` — includes `CursorModelRewriterTests`
- [x] `./create-app-bundle.sh` — release `.app` builds; binary contains `api-for-cursor.standardagents.ai` and `cursor-grok-4.5-fast`
- [x] Hosted probe: `GET https://api-for-cursor.standardagents.ai/v1/models` lists `grok-4.5` and `grok-4.5-fast`
- [x] Confirm old host `cursor-api.standardagents.ai` returns 308 → new host
- [x] Probe: `api.x.ai` accepts `grok-4.5`, rejects `grok-4.5-fast` with Model not found
- [ ] With a Cursor API key in `~/.cli-proxy-api/cursor.json`: enable Beta + Cursor, Apply models, enable Fast Mode under Grok (or select `DroidProxy: Cursor Grok 4.5 Fast`) and smoke a short `/v1/chat/completions` through `:8317`