### PR TITLE
Add Claude Opus 5 alongside Opus 4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Each release also ships a `DroidProxy-arm64.zip.sha256` checksum. Unzip and drag
 ## Features
 
 - **One-click OAuth auth** -- Claude Code, Codex, Gemini, and Kimi login launched from the Settings window, with credential monitoring and automatic OAuth token refresh.
-- **Every model, every reasoning level** -- Fable 5, Opus 4.8, Sonnet 4.6, GPT 5.4, GPT 5.5, GPT 5.6 Terra, GPT 5.6 Sol, Gemini 3.1 Pro, Gemini 3 Flash, Kimi K3, and Kimi K2.6 are registered as Factory custom models with their full set of native reasoning levels. Reasoning effort is chosen per session from Droid CLI's model selector; DroidProxy preserves the selection and the bundled backend translates it to each provider's native request format.
+- **Every model, every reasoning level** -- Fable 5, Opus 5, Sonnet 4.6, GPT 5.4, GPT 5.5, GPT 5.6 Terra, GPT 5.6 Sol, Gemini 3.1 Pro, Gemini 3 Flash, Kimi K3, and Kimi K2.6 are registered as Factory custom models with their full set of native reasoning levels. Reasoning effort is chosen per session from Droid CLI's model selector; DroidProxy preserves the selection and the bundled backend translates it to each provider's native request format.
 - **Fast Mode** -- Optional `service_tier=priority` for GPT 5.4, GPT 5.5, GPT 5.6 Terra, and GPT 5.6 Sol, toggled from the Settings window for lower-latency responses on the OpenAI Responses API.
 - **Usage tracking** -- Claude and Codex OAuth quota windows (5-hour + weekly) rendered in the **OAuth Quota Usage** section of the Settings window. Fetched directly from each provider's OAuth API (no `codex` CLI dependency) and refreshed on demand via the inline refresh button.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -32,12 +32,12 @@ Open `~/.factory/settings.json` and add the following to the `customModels` arra
       "provider": "anthropic"
     },
     {
-      "model": "claude-opus-4-8",
-      "id": "custom:droidproxy:opus-4-8",
+      "model": "claude-opus-5",
+      "id": "custom:droidproxy:opus-5",
       "index": 1,
       "baseUrl": "http://localhost:8317",
       "apiKey": "dummy-not-used",
-      "displayName": "DroidProxy: Opus 4.8",
+      "displayName": "DroidProxy: Opus 5",
       "maxOutputTokens": 128000,
       "noImageSupport": false,
       "provider": "anthropic"
@@ -144,7 +144,7 @@ Use the standard Claude, Codex, Gemini, and Kimi model aliases in the `model` fi
 Reasoning effort is selected per session in Droid CLI's model picker. DroidProxy registers each model with its native reasoning levels, preserves the selected value, and lets CLIProxyAPI translate it to the upstream provider format. Supported levels per model:
 
 - Fable 5: `low`, `medium`, `high`, `xhigh`, or `max`
-- Opus 4.8: `low`, `medium`, `high`, `xhigh`, or `max`
+- Opus 5: `low`, `medium`, `high`, `xhigh`, or `max`
 - Sonnet 4.6: `low`, `medium`, `high`, or `max`
 - GPT 5.4: `low`, `medium`, `high`, or `xhigh`
 - GPT 5.5: `low`, `medium`, `high`, or `xhigh`

--- a/patches/README.md
+++ b/patches/README.md
@@ -6,7 +6,7 @@ upstream release, bumped by `.github/workflows/update-cliproxyapi.yml`.
 When a model ships before the upstream `router-for-me/models` registry lists it,
 CLIProxyAPI returns `unknown provider for model <id>` because provider resolution
 is registry-only. To unblock those models without disabling auto-refresh, the
-bundled binary for the current release carries `cliproxy-sonnet5-overlay.patch`.
+bundled binary for the current release carries `cliproxy-opus5-overlay.patch`.
 
 ## What the patch does
 
@@ -28,11 +28,11 @@ model is again needed ahead of the registry.
 ## Rebuild
 
 ```bash
-git clone --depth 1 --branch v7.2.47 https://github.com/router-for-me/CLIProxyAPI.git
+git clone --depth 1 --branch v7.2.98 https://github.com/router-for-me/CLIProxyAPI.git
 cd CLIProxyAPI
-git apply /path/to/patches/cliproxy-sonnet5-overlay.patch
+git apply /path/to/patches/cliproxy-opus5-overlay.patch
 COMMIT=$(git rev-parse --short HEAD)
 CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build \
-  -ldflags="-s -w -X main.Version=7.2.47 -X main.Commit=${COMMIT} -X main.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  -ldflags="-s -w -X main.Version=7.2.98 -X main.Commit=${COMMIT} -X main.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   -o cli-proxy-api ./cmd/server/
 ```

--- a/patches/cliproxy-opus5-overlay.patch
+++ b/patches/cliproxy-opus5-overlay.patch
@@ -78,21 +78,21 @@ index 4c398fb..2600c0c 100644
  	if data == nil {
  		return fmt.Errorf("catalog is nil")
 diff --git a/internal/registry/models/models.json b/internal/registry/models/models.json
-index 5725cae..cc1c190 100644
+index 9060798..8e07fdf 100644
 --- a/internal/registry/models/models.json
 +++ b/internal/registry/models/models.json
-@@ -51,6 +51,29 @@
+@@ -119,6 +119,29 @@
          ]
        }
      },
 +    {
-+      "id": "claude-sonnet-5",
++      "id": "claude-opus-5",
 +      "object": "model",
-+      "created": 1782777600,
++      "created": 1784044800,
 +      "owned_by": "anthropic",
 +      "type": "claude",
-+      "display_name": "Claude Sonnet 5",
-+      "description": "Anthropic's most capable Sonnet-class model, with frontier performance across coding, agents, and professional work",
++      "display_name": "Claude Opus 5",
++      "description": "Premium model combining maximum intelligence with practical performance",
 +      "context_length": 1000000,
 +      "max_completion_tokens": 128000,
 +      "thinking": {
@@ -109,5 +109,5 @@ index 5725cae..cc1c190 100644
 +      }
 +    },
      {
-       "id": "claude-opus-4-6",
+       "id": "claude-sonnet-5",
        "object": "model",

--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -145,6 +145,18 @@ enum DroidProxyModelCatalog {
                 defaultLevelValue: "xhigh"
             ),
             DroidProxyModelDefinition(
+                baseModel: "claude-opus-5",
+                idSlug: "opus-5",
+                displayName: "Opus 5",
+                maxOutputTokens: 128000,
+                provider: "anthropic",
+                providerKey: "claude",
+                baseURL: "http://localhost:8317",
+                kind: .claudeAdaptive,
+                levels: claudeAdvancedLevels,
+                defaultLevelValue: "xhigh"
+            ),
+            DroidProxyModelDefinition(
                 baseModel: "claude-opus-4-8",
                 idSlug: "opus-4-8",
                 displayName: "Opus 4.8",
@@ -333,9 +345,9 @@ enum DroidProxyModelCatalog {
                 defaultLevelValue: "xhigh"
             ),
             DroidProxyModelDefinition(
-                baseModel: "junie-claude-opus-4-8",
-                idSlug: "junie-claude-opus-4-8",
-                displayName: "Junie Opus 4.8",
+                baseModel: "junie-claude-opus-5",
+                idSlug: "junie-claude-opus-5",
+                displayName: "Junie Opus 5",
                 maxOutputTokens: 128000,
                 provider: "anthropic",
                 providerKey: "junie",

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -823,7 +823,7 @@ struct SettingsView: View {
                         .junie,
                         iconName: "icon-junie.svg",
                         toggleTint: junieEffortSelectionColor,
-                        helpText: "Enter your JetBrains Junie API key to use your JetBrains AI subscription for Junie Sonnet 5, Opus 4.8, and Fable 5."
+                        helpText: "Enter your JetBrains Junie API key to use your JetBrains AI subscription for Junie Sonnet 5, Opus 5, and Fable 5."
                     )
 
                     providerServiceRow(

--- a/src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift
@@ -13,6 +13,29 @@ final class DroidProxyModelCatalogTests: XCTestCase {
         XCTAssertEqual(fable["maxOutputTokens"] as? Int, 128000)
     }
 
+    func testApplyWritesBothOpus5AndOpus48ForClaudeProvider() throws {
+        // Apply/Re-apply serializes every enabled definition via settingsModels();
+        // both Opus entries are providerKey "claude", so enabling Claude writes both.
+        let claudeModels = DroidProxyModelCatalog.settingsModels { $0 == "claude" }
+        let ids = Set(claudeModels.compactMap { $0["id"] as? String })
+        XCTAssertTrue(ids.contains("custom:droidproxy:opus-5"))
+        XCTAssertTrue(ids.contains("custom:droidproxy:opus-4-8"))
+
+        let opus5 = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:opus-5"))
+        XCTAssertEqual(opus5["model"] as? String, "claude-opus-5")
+        XCTAssertEqual(opus5["displayName"] as? String, "DroidProxy: Opus 5")
+
+        let opus48 = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:opus-4-8"))
+        XCTAssertEqual(opus48["model"] as? String, "claude-opus-4-8")
+        XCTAssertEqual(opus48["displayName"] as? String, "DroidProxy: Opus 4.8")
+
+        // Non-Junie only: the junie provider exposes Opus 5 but not Opus 4.8.
+        let junieIds = Set(DroidProxyModelCatalog.settingsModels { $0 == "junie" }
+            .compactMap { $0["id"] as? String })
+        XCTAssertTrue(junieIds.contains("custom:droidproxy:junie-claude-opus-5"))
+        XCTAssertFalse(junieIds.contains("custom:droidproxy:junie-claude-opus-4-8"))
+    }
+
     func testSonnet5UsesNativeModelIDAndExposesFullLevels() throws {
         let sonnet = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:sonnet-5"))
 

--- a/website/src/components/InstallSection.tsx
+++ b/website/src/components/InstallSection.tsx
@@ -14,12 +14,12 @@ const codePlain = `// What "Apply" writes for you — no need to touch this your
     "provider": "anthropic"
   },
   {
-    "model": "claude-opus-4-8",
-    "id": "custom:droidproxy:opus-4-8",
+    "model": "claude-opus-5",
+    "id": "custom:droidproxy:opus-5",
     "index": 1,
     "baseUrl": "http://localhost:8317",
     "apiKey": "***",
-    "displayName": "DroidProxy: Opus 4.8",
+    "displayName": "DroidProxy: Opus 5",
     "maxOutputTokens": 128000,
     "provider": "anthropic"
   },
@@ -49,12 +49,12 @@ const codeHtml = `<span class="c">// What "Apply" writes for you — no need to 
     <span class="k">"provider"</span>: <span class="s">"anthropic"</span>
   },
   {
-    <span class="k">"model"</span>: <span class="s">"claude-opus-4-8"</span>,
-    <span class="k">"id"</span>: <span class="s">"custom:droidproxy:opus-4-8"</span>,
+    <span class="k">"model"</span>: <span class="s">"claude-opus-5"</span>,
+    <span class="k">"id"</span>: <span class="s">"custom:droidproxy:opus-5"</span>,
     <span class="k">"index"</span>: <span class="n">1</span>,
     <span class="k">"baseUrl"</span>: <span class="s">"http://localhost:8317"</span>,
     <span class="k">"apiKey"</span>: <span class="s">"***"</span>,
-    <span class="k">"displayName"</span>: <span class="s">"DroidProxy: Opus 4.8"</span>,
+    <span class="k">"displayName"</span>: <span class="s">"DroidProxy: Opus 5"</span>,
     <span class="k">"maxOutputTokens"</span>: <span class="n">128000</span>,
     <span class="k">"provider"</span>: <span class="s">"anthropic"</span>
   },
@@ -117,7 +117,7 @@ export default function InstallSection() {
               <span className="step-n">03</span>
               <div>
                 <h4>Click <em style={{ fontStyle: 'normal', color: 'var(--accent)' }}>Apply Factory Models</em></h4>
-                <p>One click adds DroidProxy's models to your Factory Droid setup. Restart your Droid session — when you pick "DroidProxy: Opus 4.8" or any of the others, your subscription handles the bill.</p>
+                <p>One click adds DroidProxy's models to your Factory Droid setup. Restart your Droid session — when you pick "DroidProxy: Opus 5" or any of the others, your subscription handles the bill.</p>
               </div>
             </div>
 

--- a/website/src/components/ModelsSection.tsx
+++ b/website/src/components/ModelsSection.tsx
@@ -9,8 +9,8 @@ const models = [
   },
   {
     icon: '/assets/icon-claude.png',
-    name: 'Claude Opus 4.8',
-    id: 'opus-4-8',
+    name: 'Claude Opus 5',
+    id: 'opus-5',
     levels: ['low', 'medium', 'high', 'xhigh', 'max'],
     max: '128,000',
     provider: 'Anthropic',

--- a/website/src/components/UseCasesSection.tsx
+++ b/website/src/components/UseCasesSection.tsx
@@ -18,7 +18,7 @@ const cases = [
   {
     tag: '03 — Pick your lab',
     title: 'Mix and match Claude, ChatGPT & Gemini.',
-    body: 'Got a Claude Pro plan? Use Fable 5, Opus 4.8, and Sonnet 4.6. ChatGPT Plus? Run GPT-5 inside Droid. Gemini Advanced? Same. Sign in to whichever ones you have — the rest just stay disabled.',
+    body: 'Got a Claude Pro plan? Use Fable 5, Opus 5, and Sonnet 4.6. ChatGPT Plus? Run GPT-5 inside Droid. Gemini Advanced? Same. Sign in to whichever ones you have — the rest just stay disabled.',
     footLabel: 'Models',
     footValue: '8 supported · all optional',
     footRight: '3 labs',


### PR DESCRIPTION
## Summary

Adds **Claude Opus 5** (`claude-opus-5`) as a DroidProxy custom model while **keeping Opus 4.8** available.

- **General Claude provider:** both `custom:droidproxy:opus-5` (Opus 5) and `custom:droidproxy:opus-4-8` (Opus 4.8) are registered. Apply/Re-apply writes **both** entries whenever the Claude provider is enabled.
- **Junie provider:** exposes **Opus 5 only** (`junie-claude-opus-5`); no Junie Opus 4.8.

## CLIProxyAPI overlay

Opus 5 shipped before the upstream `router-for-me` model registry lists it, so registry-only provider resolution returned `unknown provider for model claude-opus-5`. Following the prior sonnet-5 pattern, the bundled binary (now **v7.2.98**) carries `patches/cliproxy-opus5-overlay.patch`, which:

- adds `claude-opus-5` to the embedded `internal/registry/models/models.json`, and
- overlays embedded-only models onto each remote refresh (`mergeEmbeddedFallback`) — remote definitions always win, so the overlay becomes a no-op once upstream publishes the model.

Remote auto-refresh stays enabled; every other model still updates normally. The obsolete `cliproxy-sonnet5-overlay.patch` is removed since upstream now ships `claude-sonnet-5`.

## Verification

- `swift build` and `swift test` pass, including a new `testApplyWritesBothOpus5AndOpus48ForClaudeProvider` regression test.
- End-to-end: with the patched binary bundled, `claude-opus-5` now resolves to the Claude provider (the registry error is gone). A control request on `claude-opus-4-8` returns cleanly.

> Note: Anthropic upstream currently returns `not_found_error` for `claude-opus-5` on the test account (Opus 5 not yet served to these credentials). The DroidProxy/CLIProxyAPI side is complete; requests will succeed once the account has Opus 5 access.

## Changes

- `src/Sources/DroidProxyModelCatalog.swift` — add Opus 5 (general + Junie), keep Opus 4.8 (general)
- `src/Sources/Resources/cli-proxy-api` — patched CLIProxyAPI v7.2.98
- `patches/` — add `cliproxy-opus5-overlay.patch`, remove `cliproxy-sonnet5-overlay.patch`, update README
- `src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift` — Apply regression test
- Docs/site: `README.md`, `SETUP.md`, `website/src/components/{ModelsSection,InstallSection,UseCasesSection}.tsx`
